### PR TITLE
ledger support for `__post_init__` fields

### DIFF
--- a/libs/analysis/aframe/analysis/ledger/events.py
+++ b/libs/analysis/aframe/analysis/ledger/events.py
@@ -95,8 +95,10 @@ class RecoveredInjectionSet(TimeSlideEventSet, InterferometerResponseSet):
         for obj in [events, responses]:
             for key in obj.__dataclass_fields__:
                 if key in cls.__dataclass_fields__:
-                    value = getattr(obj, key)
-                    kwargs[key] = value
+                    if obj.__dataclass_fields__[key].init:
+                        value = getattr(obj, key)
+                        kwargs[key] = value
+
         return cls(**kwargs)
 
     @classmethod

--- a/libs/analysis/aframe/analysis/ledger/injections.py
+++ b/libs/analysis/aframe/analysis/ledger/injections.py
@@ -35,10 +35,8 @@ class IntrinsicParameterSet(Ledger):
     tilt_2: np.ndarray = parameter()
     phi_12: np.ndarray = parameter()
     phi_jl: np.ndarray = parameter()
-
     chirp_mass: np.ndarray = parameter(init=False)
     mass_ratio: np.ndarray = parameter(init=False)
-
     mass_1_source: np.ndarray = parameter(init=False)
     mass_2_source: np.ndarray = parameter(init=False)
 

--- a/libs/analysis/aframe/analysis/ledger/injections.py
+++ b/libs/analysis/aframe/analysis/ledger/injections.py
@@ -46,7 +46,7 @@ class IntrinsicParameterSet(Ledger):
             self.mass_1 + self.mass_2
         ) ** (1 / 5)
 
-        self.mass_ratio = self.mass_1 / self.mass_2
+        self.mass_ratio = self.mass_2 / self.mass_1
         self.mass_1_source = self.mass_1 / (1 + self.redshift)
         self.mass_2_source = self.mass_2 / (1 + self.redshift)
 
@@ -249,6 +249,7 @@ class InterferometerResponseSet(
     InjectionMetadata, ExtrinsicParameterSet, IntrinsicParameterSet
 ):
     def __post_init__(self):
+        print("IRS post init")
         # initiate chain of mro __post_init__ calls
         super().__post_init__()
         self._waveforms = None

--- a/libs/analysis/aframe/analysis/ledger/injections.py
+++ b/libs/analysis/aframe/analysis/ledger/injections.py
@@ -256,7 +256,7 @@ class InterferometerResponseSet(
     InjectionMetadata, ExtrinsicParameterSet, IntrinsicParameterSet
 ):
     def __post_init__(self):
-        # IntrinsicParameterSet.__post_init__(self)
+        IntrinsicParameterSet.__post_init__(self)
         InjectionMetadata.__post_init__(self)
         self._waveforms = None
 

--- a/libs/analysis/aframe/analysis/ledger/injections.py
+++ b/libs/analysis/aframe/analysis/ledger/injections.py
@@ -43,6 +43,7 @@ class IntrinsicParameterSet(Ledger):
     mass_2_source: np.ndarray = parameter(init=False)
 
     def __post_init__(self):
+        super().__post_init__()
         self.chirp_mass = (self.mass_1 * self.mass_2) ** (3 / 5) / (
             self.mass_1 + self.mass_2
         ) ** (1 / 5)
@@ -60,13 +61,7 @@ class InjectionMetadata(Ledger):
 
     def __post_init__(self):
         # verify that all waveforms have the appropriate duration
-
-        # call Ledgers __post_init__ expicitly due to odd
-        # super() MRO behavior for classes with multiple inheritance.
-        # The new IntrinsicParameterSet __post_init__ method was being
-        # called instead of the Ledger __post_init__ method.
-
-        Ledger.__post_init__(self)
+        super().__post_init__()
         if self.num_injections < self._length:
             raise ValueError(
                 "{} has fewer total injections {} than "
@@ -256,9 +251,8 @@ class InterferometerResponseSet(
     InjectionMetadata, ExtrinsicParameterSet, IntrinsicParameterSet
 ):
     def __post_init__(self):
-        IntrinsicParameterSet.__post_init__(self)
-        InjectionMetadata.__post_init__(self)
-        self._waveforms = None
+        # initiate chain of mro __post_init__ calls
+        super().__post_init__()
 
     @property
     def waveforms(self) -> np.ndarray:

--- a/libs/analysis/aframe/analysis/ledger/injections.py
+++ b/libs/analysis/aframe/analysis/ledger/injections.py
@@ -35,6 +35,19 @@ class IntrinsicParameterSet(Ledger):
     tilt_2: np.ndarray = parameter()
     phi_12: np.ndarray = parameter()
     phi_jl: np.ndarray = parameter()
+    chirp_mass: np.ndarray = parameter(init=False)
+    mass_ratio: np.ndarray = parameter(init=False)
+    mass_1_source: np.ndarray = parameter(init=False)
+    mass_2_source: np.ndarray = parameter(init=False)
+
+    def __post_init__(self):
+        self.chirp_mass = (self.mass_1 * self.mass_2) ** (3 / 5) / (
+            self.mass_1 + self.mass_2
+        ) ** (1 / 5)
+
+        self.mass_ratio = self.mass_1 / self.mass_2
+        self.mass_1_source = self.mass_1 / (1 + self.redshift)
+        self.mass_2_source = self.mass_2 / (1 + self.redshift)
 
 
 @dataclass
@@ -45,7 +58,11 @@ class InjectionMetadata(Ledger):
 
     def __post_init__(self):
         # verify that all waveforms have the appropriate duration
-        super().__post_init__()
+
+        # call Ledgers __post_init__ expicitly due to odd
+        # super() MRO behavior for classes with multiple inheritance
+        # (e.g. InterferometerResponseSet)
+        Ledger.__post_init__(self)
         if self.num_injections < self._length:
             raise ValueError(
                 "{} has fewer total injections {} than "
@@ -235,6 +252,7 @@ class InterferometerResponseSet(
     InjectionMetadata, ExtrinsicParameterSet, IntrinsicParameterSet
 ):
     def __post_init__(self):
+        IntrinsicParameterSet.__post_init__(self)
         InjectionMetadata.__post_init__(self)
         self._waveforms = None
 

--- a/libs/analysis/aframe/analysis/ledger/injections.py
+++ b/libs/analysis/aframe/analysis/ledger/injections.py
@@ -35,8 +35,10 @@ class IntrinsicParameterSet(Ledger):
     tilt_2: np.ndarray = parameter()
     phi_12: np.ndarray = parameter()
     phi_jl: np.ndarray = parameter()
+
     chirp_mass: np.ndarray = parameter(init=False)
     mass_ratio: np.ndarray = parameter(init=False)
+
     mass_1_source: np.ndarray = parameter(init=False)
     mass_2_source: np.ndarray = parameter(init=False)
 
@@ -60,8 +62,10 @@ class InjectionMetadata(Ledger):
         # verify that all waveforms have the appropriate duration
 
         # call Ledgers __post_init__ expicitly due to odd
-        # super() MRO behavior for classes with multiple inheritance
-        # (e.g. InterferometerResponseSet)
+        # super() MRO behavior for classes with multiple inheritance.
+        # The new IntrinsicParameterSet __post_init__ method was being
+        # called instead of the Ledger __post_init__ method.
+
         Ledger.__post_init__(self)
         if self.num_injections < self._length:
             raise ValueError(
@@ -252,7 +256,7 @@ class InterferometerResponseSet(
     InjectionMetadata, ExtrinsicParameterSet, IntrinsicParameterSet
 ):
     def __post_init__(self):
-        IntrinsicParameterSet.__post_init__(self)
+        # IntrinsicParameterSet.__post_init__(self)
         InjectionMetadata.__post_init__(self)
         self._waveforms = None
 

--- a/libs/analysis/aframe/analysis/ledger/injections.py
+++ b/libs/analysis/aframe/analysis/ledger/injections.py
@@ -251,6 +251,7 @@ class InterferometerResponseSet(
     def __post_init__(self):
         # initiate chain of mro __post_init__ calls
         super().__post_init__()
+        self._waveforms = None
 
     @property
     def waveforms(self) -> np.ndarray:

--- a/libs/analysis/aframe/analysis/ledger/injections.py
+++ b/libs/analysis/aframe/analysis/ledger/injections.py
@@ -249,7 +249,6 @@ class InterferometerResponseSet(
     InjectionMetadata, ExtrinsicParameterSet, IntrinsicParameterSet
 ):
     def __post_init__(self):
-        print("IRS post init")
         # initiate chain of mro __post_init__ calls
         super().__post_init__()
         self._waveforms = None

--- a/libs/analysis/aframe/analysis/ledger/ledger.py
+++ b/libs/analysis/aframe/analysis/ledger/ledger.py
@@ -12,9 +12,9 @@ PATH = Union[str, bytes, os.PathLike]
 # define metadata for various types of injection set attributes
 # so that they can be easily extended by just annotating your
 # new argument with the appropriate type of field
-def parameter(default=None):
+def parameter(default=None, init=True):
     default = default or np.array([])
-    return field(metadata={"kind": "parameter"}, default=default)
+    return field(init=init, metadata={"kind": "parameter"}, default=default)
 
 
 def waveform(default=None):
@@ -84,7 +84,8 @@ class Ledger:
                 except TypeError:
                     value = np.array([value])
 
-            init_kwargs[key] = value
+            if attr.init:
+                init_kwargs[key] = value
         return type(self)(**init_kwargs)
 
     def _get_group(self, f: h5py.File, name: str):
@@ -167,7 +168,8 @@ class Ledger:
                 else:
                     value = value[:]
 
-            kwargs[key] = value
+            if attr.init:
+                kwargs[key] = value
         return cls(**kwargs)
 
     @classmethod

--- a/libs/analysis/aframe/analysis/ledger/ledger.py
+++ b/libs/analysis/aframe/analysis/ledger/ledger.py
@@ -41,7 +41,7 @@ class Ledger:
         # everything that isn't metadata has the same length
         _length = None
         for key, attr in self.__dataclass_fields__.items():
-            if attr.metadata["kind"] == "metadata":
+            if attr.metadata["kind"] == "metadata" or not attr.init:
                 continue
             value = getattr(self, key)
 
@@ -159,6 +159,8 @@ class Ledger:
                     "Couldn't load unknown annotation {} "
                     "for field {}".format(kind, key)
                 )
+            elif attr.init:
+                continue
             else:
                 value = _try_get(kind + "s", key)
                 if idx is not None:
@@ -168,8 +170,6 @@ class Ledger:
                 else:
                     value = value[:]
 
-            if attr.init:
-                kwargs[key] = value
         return cls(**kwargs)
 
     @classmethod

--- a/libs/analysis/aframe/analysis/ledger/ledger.py
+++ b/libs/analysis/aframe/analysis/ledger/ledger.py
@@ -159,7 +159,7 @@ class Ledger:
                     "Couldn't load unknown annotation {} "
                     "for field {}".format(kind, key)
                 )
-            elif attr.init:
+            elif not attr.init:
                 continue
             else:
                 value = _try_get(kind + "s", key)
@@ -170,6 +170,7 @@ class Ledger:
                 else:
                     value = value[:]
 
+            kwargs[key] = value
         return cls(**kwargs)
 
     @classmethod

--- a/libs/analysis/tests/ledger/test_events.py
+++ b/libs/analysis/tests/ledger/test_events.py
@@ -100,7 +100,7 @@ class TestRecoveredInjectionSet:
         for name, attr in fields.items():
             if name == "gps_time" or name == "sample_rate":
                 continue
-            if attr.metadata["kind"] == "parameter":
+            if attr.metadata["kind"] == "parameter" and attr.init:
                 params[name] = np.arange(3)
 
         return injections.InterferometerResponseSet(num_injections=5, **params)

--- a/libs/analysis/tests/ledger/test_injections.py
+++ b/libs/analysis/tests/ledger/test_injections.py
@@ -28,7 +28,7 @@ class TestLigoResponseSet:
 
         fields = injections.LigoResponseSet.__dataclass_fields__
         for name, attr in fields.items():
-            if attr.metadata["kind"] == "parameter":
+            if attr.metadata["kind"] == "parameter" and attr.init:
                 params[name] = np.zeros((N,))
             elif attr.metadata["kind"] == "waveform":
                 waveforms[name] = np.ones((N, size))


### PR DESCRIPTION
Adds support to the `ledger` API for derived fields that can be initialized in `__post_init__`. For example, chirp mass, source frame masses, mass ratio etc in  `IntrinsicParameterSet`

