### PR TITLE
Validation fixes

### DIFF
--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -139,7 +139,7 @@ highpass = "${base.minimum_frequency}"
 psd_length = "${base.training_psd_length}"
 
 # augmentation args
-trigger_distance = -0.5
+trigger_distance = -0.75
 waveform_prob = 0.5
 
 swap_frac = 0.025

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -118,16 +118,13 @@ logdir = "${base.logdir}"
 outdir = "${base.basedir}/training"
 
 # optimization args
-
-batch_size = 640
-
-
+batch_size = 384
 max_epochs = 200
 max_lr = 1e-3
 lr_ramp_epochs = 9
 weight_decay = 0.0
 
-snr_thresh = 0
+snr_thresh = 4
 max_min_snr = 12
 max_snr = 100
 snr_alpha = 3

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -127,7 +127,7 @@ max_lr = 1e-3
 lr_ramp_epochs = 9
 weight_decay = 0.0
 
-snr_thresh = 4
+snr_thresh = 0
 max_min_snr = 12
 max_snr = 100
 snr_alpha = 3

--- a/projects/sandbox/train/tests/test_train.py
+++ b/projects/sandbox/train/tests/test_train.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 import pytest
-import torch
 from train.train import main as train
 
 
@@ -137,14 +136,14 @@ def test_train(
     waveforms_mock = patch(
         "train.utils.get_waveforms",
         return_value=(
-            torch.randn(900, 2, sample_rate * 8),
-            torch.randn(100, 2, sample_rate * 8),
+            np.random.randn(900, 2, sample_rate * 8),
+            np.random.randn(100, 2, sample_rate * 8),
         ),
     )
 
     background_mock = patch(
         "train.utils.get_background",
-        return_value=torch.randn(2, 1024 * sample_rate),
+        return_value=np.random.randn(2, 1024 * sample_rate),
     )
 
     with background_fnames_mock, waveforms_mock, background_mock as _, _, _:

--- a/projects/sandbox/train/train/augmentor.py
+++ b/projects/sandbox/train/train/augmentor.py
@@ -148,11 +148,8 @@ class AframeBatchAugmentor(torch.nn.Module):
 
         # perform swapping and muting augmentations
         # on those responses, and then inject them
-        print(responses.shape)
         responses, swap_indices = self.swapper(responses)
-        print(responses.shape)
         responses, mute_indices = self.muter(responses)
-        print(X.shape)
         X[mask] += responses
 
         # now that injections have been made,

--- a/projects/sandbox/train/train/train.py
+++ b/projects/sandbox/train/train/train.py
@@ -50,6 +50,7 @@ def main(
     # validation args
     valid_frac: Optional[float] = None,
     valid_stride: Optional[float] = None,
+    num_valid_views: int = 5,
     max_fpr: float = 1e-3,
     valid_livetime: float = (3600 * 12),
     early_stop: Optional[int] = None,
@@ -259,6 +260,8 @@ def main(
             shift=1,
             max_fpr=max_fpr,
             device=device,
+            pad=trigger_distance,
+            num_views=num_valid_views,
         )
     else:
         validator = None

--- a/projects/sandbox/train/train/train.py
+++ b/projects/sandbox/train/train/train.py
@@ -276,7 +276,7 @@ def main(
         alpha=snr_alpha,
         decay_steps=snr_decay_steps,
     )
-    print(waveforms)
+
     cross, plus = waveforms.transpose(1, 0)
     augmentor = AframeBatchAugmentor(
         ifos,

--- a/projects/sandbox/train/train/train.py
+++ b/projects/sandbox/train/train/train.py
@@ -260,7 +260,7 @@ def main(
             shift=1,
             max_fpr=max_fpr,
             device=device,
-            pad=trigger_distance,
+            pad=-trigger_distance,
             num_views=num_valid_views,
         )
     else:

--- a/projects/sandbox/train/train/train.py
+++ b/projects/sandbox/train/train/train.py
@@ -277,7 +277,7 @@ def main(
         decay_steps=snr_decay_steps,
     )
 
-    cross, plus = waveforms.transpose(1, 0)
+    cross, plus = waveforms.transpose(1, 0, 2)
     augmentor = AframeBatchAugmentor(
         ifos,
         sample_rate,
@@ -305,7 +305,7 @@ def main(
     # to account for our sky parameter sampling
     # and to balance compute vs. validation resolution
     waveforms_per_batch = batch_size * waveform_prob
-    batches_per_epoch = int(2 * len(waveforms) / waveforms_per_batch)
+    batches_per_epoch = int(4 * len(waveforms) / waveforms_per_batch)
     train_dataset = structures.ChunkedDataloader(
         background_fnames,
         ifos=ifos,
@@ -316,8 +316,8 @@ def main(
         # or set some sensible defaults?
         reads_per_chunk=10,
         chunk_length=1024,
-        batches_per_chunk=int(batches_per_epoch / 4),
-        chunks_per_epoch=4,
+        batches_per_chunk=int(batches_per_epoch / 8),
+        chunks_per_epoch=8,
         device=device,
         preprocessor=augmentor,
     )


### PR DESCRIPTION
Adding multiple-view inference on signals and commenting our SNR thresholding right now during validation. Also fixes a couple bugs to get training running and reduces batch size to be able to fit the 1.5s kernel on a V100, and increases batches per epoch to balance out the longer validation time.

Need to do some actual testing to make sure my implementation is doing what I think it does. It seems to be correct, but the convergence behavior is very different. This is also very possibly because of the different kernel size/hyperparameters, so will be worth tracking these things down before launching a hyperparameter search run.