### PR TITLE
Changes required to get pipeline running

### DIFF
--- a/libs/architectures/aframe/architectures/resnet.py
+++ b/libs/architectures/aframe/architectures/resnet.py
@@ -79,7 +79,7 @@ def get_norm_layer(groups: Optional[int] = None) -> nn.Module:
             num_groups = None if groups is None else min(num_channels, groups)
             super().__init__(num_channels, num_groups)
 
-    return GroupNorm
+    return NormLayer
 
 
 def convN(

--- a/projects/sandbox/datagen/datagen/scripts/waveforms.py
+++ b/projects/sandbox/datagen/datagen/scripts/waveforms.py
@@ -8,6 +8,7 @@ from datagen.utils.injection import generate_gw
 from typeo import scriptify
 
 from aframe.logging import configure_logging
+from aframe.priors.priors import convert_mdc_prior_samples
 
 
 @scriptify
@@ -86,6 +87,7 @@ def main(
     # sample gw parameters
     prior, detector_frame_prior = prior()
     params = prior.sample(num_signals)
+    params = convert_mdc_prior_samples(params)
 
     signals = generate_gw(
         params,

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -164,7 +164,7 @@ commands.resnet = "${base.resnet}"
 [tool.typeo.scripts.export-model]
 # paths
 repository_directory = "${base.repository_directory}" 
-outdir = "${base.logdir}"
+logdir = "${base.logdir}"
 weights = "${base.basedir}/training/weights.pt"
 
 # input-output mapping info

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -2,7 +2,6 @@
 steps = [
     "datagen:deploy-background",
     "datagen:generate-waveforms",
-    "datagen:generate-glitches",
     "datagen:deploy-timeslide-waveforms",
     "train:train:resnet",
     "export:export-model:resnet",
@@ -109,7 +108,6 @@ sample_rate = "${base.sample_rate}"
 waveform_duration = "${base.waveform_duration}"
 force_generation = "${base.force_generation}"
 waveform_approximant = "${base.waveform_approximant}"
-cosmology = "${base.cosmology}"
 
 [tool.typeo.scripts.train]
 # input and output paths
@@ -218,7 +216,6 @@ reference_frequency = "${base.reference_frequency}"
 highpass = "${base.highpass}"
 spacing = 48
 buffer = 16
-cosmology = "${base.cosmology}"
 snr_threshold = 0 
 waveform_duration = "${base.waveform_duration}"
 waveform_approximant = "${base.waveform_approximant}"


### PR DESCRIPTION
Closes #390 . Still some minor issues keeping the pipeline from running end-to-end. Most notably
- parameter conversion during training waveform generation and removal of `cosmology` argument in config (specific to the MDC prior, but still worth having a functioning `main`)
- Gets rid of glitch generation step for now until it can be fixed and #374 gets merged
- Fixes the bug mentioned in #390 that functionally ignores the `norm_groups` parameter

Pipeline should be able to run end-to-end after this. Would be curious to have someone verify this