### PR TITLE
Prevent inference from stopping early

### DIFF
--- a/projects/sandbox/infer/infer/callback.py
+++ b/projects/sandbox/infer/infer/callback.py
@@ -120,6 +120,8 @@ class Callback:
         window_size = int(
             self.integration_window_length * self.inference_sampling_rate
         )
+        if window_size == 1:
+            return y
         window = np.ones((window_size,)) / window_size
         integrated = np.convolve(y, window, mode="full")
         return integrated[: -window_size + 1]

--- a/projects/sandbox/infer/infer/data/batcher.py
+++ b/projects/sandbox/infer/infer/data/batcher.py
@@ -86,7 +86,13 @@ def batch_chunks(
         return
     else:
         if x.shape[-1] < step_size:
-            return
+            # It's fine that there's data available as long as it's
+            # less than step_size, but we still need to iterate the
+            # data loader to line up queue entries in loader.py
+            try:
+                x, _ = next(it)
+            except StopIteration:
+                return
         raise ValueError(
             "Data iterator expected to have {} "
             "steps, but data still available".format(num_steps)

--- a/projects/sandbox/infer/infer/deploy.py
+++ b/projects/sandbox/infer/infer/deploy.py
@@ -84,7 +84,7 @@ def get_ip_address() -> str:
     Currently not a general function.
     """
     nets = psutil.net_if_addrs()
-    return nets["eno8303"][0].address
+    return nets["enp1s0f0"][0].address
 
 
 @scriptify

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -31,7 +31,7 @@ resnet = {layers = [3, 4, 6, 3], norm_groups = 16}
 repository_directory = "${BASE_DIR}/model_repo/" 
 force_generation = false
 Tb = 31536000  # 1 year of background
-inference_sampling_rate = 16
+inference_sampling_rate = 2
 inference_batch_size = 128
 inference_psd_length = 64
 training_psd_length = 8
@@ -233,7 +233,7 @@ sequence_id = 1001
 # timeslide args
 Tb = "${base.Tb}"
 shifts = [0, 1]
-throughput = 80
+throughput = 640
 
 # data args
 sample_rate = "${base.sample_rate}"


### PR DESCRIPTION
What I described as a workaround is probably actually a reasonable way to resolve this issue.

The issue arises when a segment has `duration%chunk_length < (step_size / sample_rate)` (with `step_size` defined [here](https://github.com/ML4GW/aframe/blob/ba0e76c64d3676718901f79a03bcec6fee65d301/projects/sandbox/infer/infer/data/batcher.py#L21)). In that case, we'll have a little bit of data left over during `batch_chunks`, which enters us into [this](https://github.com/ML4GW/aframe/blob/ba0e76c64d3676718901f79a03bcec6fee65d301/projects/sandbox/infer/infer/data/batcher.py#L88) `if` statement. However, the `return` there breaks the `while` loop happening in `segment_gen`, meaning that we go into the next iteration of the loop in `_iter_through_q` with a `None` in the queue. This `None` is meant to indicate to `segment_gen` that the segment is finished, but it instead tells `_iter_through_q` that we're done with all the segments.

The way I get around this is to ensure that the data is exhausted inside `batch_chunks` so that the queue is aligned with what's happening in the loader.