### PR TITLE
remove unused `state_flag` arg from timeslide script

### DIFF
--- a/projects/sandbox/datagen/datagen/scripts/timeslide_waveforms.py
+++ b/projects/sandbox/datagen/datagen/scripts/timeslide_waveforms.py
@@ -280,7 +280,6 @@ def deploy(
     logdir: Path,
     accounting_group_user: str,
     accounting_group: str,
-    state_flag: Optional[str] = None,
     request_memory: int = 6000,
     request_disk: int = 1024,
     force_generation: bool = False,


### PR DESCRIPTION
@wbenoit26 Not sure how this snuck past the linting.