### PR TITLE
getting production training/eval working

### DIFF
--- a/libs/priors/aframe/priors/priors.py
+++ b/libs/priors/aframe/priors/priors.py
@@ -237,17 +237,6 @@ def gaussian_masses(
     return prior, detector_frame_prior
 
 
-def get_log_normal_params(mean, std):
-    """
-    Calculate the mean and standard deviation of the normal
-    distribution associated with the lognormal distribution
-    defined by the given mean and standard deviation
-    """
-    sigma = np.log((std / mean) ** 2 + 1) ** 0.5
-    mu = 2 * np.log(mean / (mean**2 + std**2) ** 0.25)
-    return mu, sigma
-
-
 def log_normal_masses(
     m1: float,
     m2: float,
@@ -277,10 +266,8 @@ def log_normal_masses(
     """
     prior = PriorDict(conversion_function=mass_constraints)
 
-    mu1, sigma1 = get_log_normal_params(m1, sigma)
-    mu2, sigma2 = get_log_normal_params(m2, sigma)
-    prior["mass_1"] = LogNormal(name="mass_1", mu=mu1, sigma=sigma1)
-    prior["mass_2"] = LogNormal(name="mass_2", mu=mu2, sigma=sigma2)
+    prior["mass_1"] = LogNormal(name="mass_1", mu=np.log(m1), sigma=sigma)
+    prior["mass_2"] = LogNormal(name="mass_2", mu=np.log(m2), sigma=sigma)
     prior["mass_ratio"] = Constraint(0.02, 1)
 
     prior["redshift"] = UniformSourceFrame(

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -18,7 +18,7 @@ logdir = "${BASE_DIR}/log"
 sample_rate = 2048
 kernel_length = 1.5
 ifos = ['H1', 'L1']
-hopeless_snr_thresh = 3
+hopeless_snr_thresh = 4
 global_seed = 42
 
 train_start = 1240579783
@@ -235,7 +235,7 @@ sequence_id = 1001
 # timeslide args
 Tb = "${base.Tb}"
 shifts = [0, 1]
-throughput = 640
+throughput = 1000
 
 # data args
 sample_rate = "${base.sample_rate}"


### PR DESCRIPTION
- Moved hopeless SNR threshold back up to 4 from 3
- Increased inference throughput to reflect lower inference sampling rate
- Switching log normal parameters for evaluation to better reflect GWTC-3

I have not generated a test dataset using the new SNR threshold, so the trained model will need to be evaluated on that. But have otherwise confirmed this reproduces SOA results and is ready for production.