### PR TITLE
Remove popping of `fit` arg in `TuneRemote`

### DIFF
--- a/aframe/tasks/train/base.py
+++ b/aframe/tasks/train/base.py
@@ -58,11 +58,6 @@ class TrainBaseParameters(law.Task):
         "files used for training",
         default=paths().train_datadir,
     )
-    ckpt_path = PathParameter(
-        default="",
-        description="Path to checkpoint file from which "
-        "to restart training",
-    )
 
 
 @inherits(TrainBaseParameters)

--- a/aframe/tasks/train/tune.py
+++ b/aframe/tasks/train/tune.py
@@ -114,9 +114,6 @@ class TuneRemote(RemoteTrainBase, AframeRayTask):
 
         args = ["--config", self.tune_config, "--"]
         lightning_args = self.get_args()
-        lightning_args.pop(
-            0
-        )  # remove "fit" subcommand since lightray takes care of it
         args.extend(lightning_args)
 
         results = cli(args)


### PR DESCRIPTION
Also removes `ckpt_path` from `law` Task since it can now just be specified directly in the lightning yaml