### PR TITLE
Directly specify `fftlength` in config

### DIFF
--- a/aframe/pipelines/sandbox/configs/base.cfg
+++ b/aframe/pipelines/sandbox/configs/base.cfg
@@ -36,7 +36,7 @@ prior = priors.priors.end_o3_ratesandpops
 
 # data conditioning / preprocessing parameters
 
-# keep empty to use the default;
+# keep empty to use the default
 fftlength = 
 sample_rate = 2048
 fduration = 1

--- a/aframe/pipelines/sandbox/configs/base.cfg
+++ b/aframe/pipelines/sandbox/configs/base.cfg
@@ -35,7 +35,9 @@ batch_size = 512
 prior = priors.priors.end_o3_ratesandpops
 
 # data conditioning / preprocessing parameters
-fftlength = ""
+
+
+fftlength = 
 sample_rate = 2048
 fduration = 1
 highpass = 32

--- a/aframe/pipelines/sandbox/configs/base.cfg
+++ b/aframe/pipelines/sandbox/configs/base.cfg
@@ -36,7 +36,7 @@ prior = priors.priors.end_o3_ratesandpops
 
 # data conditioning / preprocessing parameters
 
-
+# keep empty to use the default;
 fftlength = 
 sample_rate = 2048
 fduration = 1

--- a/aframe/pipelines/sandbox/configs/base.cfg
+++ b/aframe/pipelines/sandbox/configs/base.cfg
@@ -35,6 +35,7 @@ batch_size = 512
 prior = priors.priors.end_o3_ratesandpops
 
 # data conditioning / preprocessing parameters
+fftlength = ""
 sample_rate = 2048
 fduration = 1
 highpass = 32
@@ -126,6 +127,7 @@ request_disk = 200MB
 request_cpus = 1
 
 [luigi_ExportLocal]
+fftlength = &::luigi_base::fftlength
 fduration = &::luigi_base::fduration
 kernel_length = &::luigi_base::kernel_length
 inference_sampling_rate = &::luigi_base::inference_sampling_rate

--- a/aframe/pipelines/sandbox/configs/bbh.cfg
+++ b/aframe/pipelines/sandbox/configs/bbh.cfg
@@ -21,6 +21,7 @@ buffer = 16
 
 [luigi_Train]
 ifos = &::luigi_base::ifos
+fftlength = &::luigi_base::fftlength
 kernel_length = &::luigi_base::kernel_length
 sample_rate = &::luigi_base::sample_rate
 highpass = &::luigi_base::highpass

--- a/aframe/pipelines/sandbox/configs/bns.cfg
+++ b/aframe/pipelines/sandbox/configs/bns.cfg
@@ -30,6 +30,7 @@ buffer = 90
 
 [luigi_Train]
 ifos = &::luigi_base::ifos
+fftlength = &::luigi_base::fftlength
 kernel_length = &::luigi_base::kernel_length
 sample_rate = &::luigi_base::sample_rate
 highpass = &::luigi_base::highpass

--- a/aframe/pipelines/sandbox/configs/review.cfg
+++ b/aframe/pipelines/sandbox/configs/review.cfg
@@ -30,6 +30,7 @@ reference_frequency = 50
 coalescence_time = 6
 
 # training parameters
+fftlength = ""
 kernel_length = 1.5
 batch_size = 512
 prior = priors.priors.end_o3_ratesandpops
@@ -82,6 +83,7 @@ request_disk = 200MB
 request_cpus = 1
 
 [luigi_ExportLocal]
+fftlength = &::luigi_base::fftlength
 fduration = &::luigi_base::fduration
 kernel_length = &::luigi_base::kernel_length
 inference_sampling_rate = &::luigi_base::inference_sampling_rate

--- a/aframe/pipelines/sandbox/configs/review.cfg
+++ b/aframe/pipelines/sandbox/configs/review.cfg
@@ -30,7 +30,7 @@ reference_frequency = 50
 coalescence_time = 6
 
 # training parameters
-fftlength = ""
+fftlength = 
 kernel_length = 1.5
 batch_size = 512
 prior = priors.priors.end_o3_ratesandpops

--- a/aframe/pipelines/sandbox/configs/review.cfg
+++ b/aframe/pipelines/sandbox/configs/review.cfg
@@ -30,12 +30,14 @@ reference_frequency = 50
 coalescence_time = 6
 
 # training parameters
-fftlength = 
 kernel_length = 1.5
 batch_size = 512
 prior = priors.priors.end_o3_ratesandpops
 
 # data conditioning / preprocessing parameters
+
+# keep empty to use the default
+fftlength = 
 sample_rate = 2048
 fduration = 1
 highpass = 32

--- a/aframe/pipelines/sandbox/configs/tune.cfg
+++ b/aframe/pipelines/sandbox/configs/tune.cfg
@@ -12,6 +12,7 @@ inherit = $AFRAME_REPO/aframe/pipelines/sandbox/configs/base.cfg
 [luigi_TuneTask]
 config = $AFRAME_REPO/projects/train/config.yaml
 tune_config = $AFRAME_REPO/projects/train/configs/tune.yaml
+fftlength = &::luigi_base::fftlength
 ifos = &::luigi_base::ifos
 kernel_length = &::luigi_base::kernel_length
 sample_rate = &::luigi_base::sample_rate


### PR DESCRIPTION
The fftlength was not  specified in the `.cfg` `luigi_base` header. This lead to potential bugs occurring when users set this explicitly in `Train` task header, but didn't to the downstream `Export` task. 

Now this is explicitly referenced from the `base` to make it clear that this parameter is shared between tasks. 