### PR TITLE
Fix minor bug with calculation of integration window length bug

### DIFF
--- a/projects/infer/infer/postprocess.py
+++ b/projects/infer/infer/postprocess.py
@@ -47,8 +47,8 @@ class Postprocessor:
         self.offset = int(psd_length * inference_sampling_rate)
 
         # convert our window lengths to sample units
-        self.integration_window_size = int(
-            inference_sampling_rate * integration_window_length
+        self.integration_window_size = (
+            int(inference_sampling_rate * integration_window_length) + 1
         )
         self.cluster_window_size = int(
             inference_sampling_rate * cluster_window_length


### PR DESCRIPTION
Thanks to @wbenoit26 for discovering this. 

Fixes issue where integration window length is one sample short. This is most noticeable for low inference sampling rates, and can lead to bias on our estimated coalescence time. 

