### PR TITLE
Apptainer poetry and W&B entity fix

### DIFF
--- a/docs/projects/train.md
+++ b/docs/projects/train.md
@@ -73,12 +73,12 @@ You can even train using multiple GPUS for free! Just specify a list of comma-se
 ##### Weights & Biases (WandB)
 `Aframe` uses [WandB](https://docs.wandb.ai/?_gl=1*csft4n*_ga*Njk1NDUzNjcyLjE3MTI4NDYyNTA.*_ga_JH1SJHJQXJ*MTcxMzI4NzY0NC4yOC4xLjE3MTMyODc2NDUuNTkuMC4w) for experiment tracking. WandB already has built-in integration with lightning.
 
-You can assign various attributes to your W&B logger
+You can assign various attributes to your W&B logger in the `luigi.cfg` file present in `aframe`'s root directory
 - name: name the run will be assigned
 - group: group to which the run will be assigned. This is useful for runs that are part of the same experiment but execute in different scripts, e.g. a hyperparameter sweep or maybe separate train, inferenence, and evaluation scripts
 - tags: comma-separated list of tags to give your run. Makes it easy to filter in the dashboard e.g. for autoencoder runs
-- project: the workspace consisting of multiple related experiments that your run is a part of, e.g. aframe
-- entity: the group managing the experiments your run is associated, e.g. ml4gw. If left blank, the project and run will be associated with your personal account
+- project: the workspace consisting of multiple related experiments that your run is a part of, by default this is set to `aframe`
+- entity: the group managing the experiments your run is associated, e.g. ml4gw. By default, this is left blank, resulting in the project and run being associated with your personal account
 
 > **_Note_** All the attributes above can also be configured via [environment variables](https://docs.wandb.ai/guides/track/environment-variables#optional-environment-variables)
 

--- a/luigi.cfg
+++ b/luigi.cfg
@@ -3,7 +3,7 @@ local_scheduler = true
 module = aframe
 
 [wandb]
-entity = ml4gw
+entity = 
 project = aframe
 
 

--- a/projects/export/apptainer.def
+++ b/projects/export/apptainer.def
@@ -18,8 +18,7 @@ Stage: build
 # poetry has already done dependency resolution for us,
 # so turn that off with the --no-deps flag to increase performance.
 # Lastly, install the export project itself
-python -m pip install poetry==1.7.1
-pip install poetry-plugin-export
+python -m pip install poetry poetry-plugin-export
 cd /opt/aframe/projects/export
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt

--- a/projects/export/apptainer.def
+++ b/projects/export/apptainer.def
@@ -18,7 +18,7 @@ Stage: build
 # poetry has already done dependency resolution for us,
 # so turn that off with the --no-deps flag to increase performance.
 # Lastly, install the export project itself
-python -m pip install poetry poetry-plugin-export
+python -m pip install poetry==2.0.1 poetry-plugin-export
 cd /opt/aframe/projects/export
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt

--- a/projects/infer/apptainer.def
+++ b/projects/infer/apptainer.def
@@ -22,7 +22,7 @@ Stage: build
 # the virtualenv package in the base environment, so
 # we'll hard pin it to the value we need.
 # TODO: there's got to be a better solution here
-python -m pip install poetry poetry-plugin-export
+python -m pip install poetry==2.0.1 poetry-plugin-export
 cd /opt/aframe/projects/infer
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt

--- a/projects/infer/apptainer.def
+++ b/projects/infer/apptainer.def
@@ -22,8 +22,7 @@ Stage: build
 # the virtualenv package in the base environment, so
 # we'll hard pin it to the value we need.
 # TODO: there's got to be a better solution here
-python -m pip install poetry==1.7.1
-pip install poetry-plugin-export
+python -m pip install poetry poetry-plugin-export
 cd /opt/aframe/projects/infer
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt

--- a/projects/plots/apptainer.def
+++ b/projects/plots/apptainer.def
@@ -20,7 +20,7 @@ Stage: build
 # poetry has already done dependency resolution for us,
 # so turn that off with the --no-deps flag to increase performance.
 # Lastly, install the export project itself
-python -m pip install poetry poetry-plugin-export
+python -m pip install poetry==2.0.1 poetry-plugin-export
 cd /opt/aframe/projects/plots
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt

--- a/projects/plots/apptainer.def
+++ b/projects/plots/apptainer.def
@@ -20,8 +20,7 @@ Stage: build
 # poetry has already done dependency resolution for us,
 # so turn that off with the --no-deps flag to increase performance.
 # Lastly, install the export project itself
-python -m pip install poetry
-pip install poetry-plugin-export
+python -m pip install poetry poetry-plugin-export
 cd /opt/aframe/projects/plots
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt

--- a/projects/train/apptainer.def
+++ b/projects/train/apptainer.def
@@ -23,8 +23,7 @@ Stage: build
 # the virtualenv package in the base environment, so
 # we'll hard pin it to the value we need.
 # TODO: there's got to be a better solution here
-python -m pip install poetry
-pip install poetry-plugin-export
+python -m pip install poetry poetry-plugin-export
 cd /opt/aframe/projects/train
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt

--- a/projects/train/apptainer.def
+++ b/projects/train/apptainer.def
@@ -23,7 +23,7 @@ Stage: build
 # the virtualenv package in the base environment, so
 # we'll hard pin it to the value we need.
 # TODO: there's got to be a better solution here
-python -m pip install poetry poetry-plugin-export
+python -m pip install poetry==2.0.1 poetry-plugin-export
 cd /opt/aframe/projects/train
 poetry export -o requirements.txt --without-hashes \
     && sed -i 's|\(.*\) @ file://|-e |' requirements.txt


### PR DESCRIPTION
Install the latest version of poetry (v2.0.1) and install the `poetry-plugin-export` plugin to export the `requirements.txt`. 

This also changes the default entity for W&B in the `luigi.cfg` to be blank, ensuring that the runs are sent to the user's personal account instead of throwing an error for forbidden access to the previous default of `ml4gw`.