### PR TITLE
Reduced latencies in accessing shared memory

### DIFF
--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -126,8 +126,7 @@ def process_event(
         std_scaler=scaler,
         device=device,
     )
-    for i, sample in enumerate(descaled_samples.flatten()):
-        shared_samples[i] = sample
+    shared_samples[:] = descaled_samples.cpu().numpy().flatten()
     amplfi_queue.put((event, ifos))
 
     # save nn output, amplfi psds, and amplfi whitened strain

--- a/projects/online/online/subprocesses/amplfi.py
+++ b/projects/online/online/subprocesses/amplfi.py
@@ -32,7 +32,7 @@ def amplfi_subprocess(
         if isinstance(arg[0], Event):
             event, amplfi_ifos = arg
             descaled_samples = torch.reshape(
-                torch.Tensor(shared_samples), (-1, len(inference_params))
+                torch.Tensor(shared_samples[:]), (-1, len(inference_params))
             )
             logger.info("Post-processing samples")
             result = postprocess_samples(
@@ -71,7 +71,7 @@ def amplfi_subprocess(
             graceid = arg
             event, amplfi_ifos = amplfi_queue.get()
             descaled_samples = torch.reshape(
-                torch.Tensor(shared_samples), (-1, len(inference_params))
+                torch.Tensor(shared_samples[:]), (-1, len(inference_params))
             )
             logger.info("Post-processing samples")
             result = postprocess_samples(

--- a/projects/online/online/utils/pe.py
+++ b/projects/online/online/utils/pe.py
@@ -19,14 +19,13 @@ if TYPE_CHECKING:
 
 
 def filter_samples(samples, parameter_sampler, inference_params):
-    net_mask = torch.ones(samples.shape[0], dtype=bool, device=samples.device)
+    net_mask = torch.ones(samples.shape[0], dtype=bool)
     priors = parameter_sampler.parameters
     for i, param in enumerate(inference_params):
         prior = priors[param]
         curr_samples = samples[:, i]
         log_probs = prior.log_prob(curr_samples)
         mask = log_probs == float("-inf")
-        mask = mask.to(curr_samples.device)
 
         logging.debug(
             f"Removed {mask.sum()}/{len(mask)} samples for parameter "


### PR DESCRIPTION
@EthanMarx I must have had a typo when I tried this previously, but you can indeed set the entire shared array at once. It's also faster to get the data as a `Tensor` using `[:]`, and not needing to send the mask to GPU when filtering speeds that process up as well.

I confirmed that the data in `shared_samples` matches the data in `descaled_samples`, so we shouldn't have any bug with that like we had before.