### PR TITLE
Properly handle logging with multiprocesses

### DIFF
--- a/projects/online/online/cli.py
+++ b/projects/online/online/cli.py
@@ -1,11 +1,4 @@
-import logging
-
-import sys
-from datetime import datetime, timezone
-from logging.handlers import TimedRotatingFileHandler
-from pathlib import Path
 import jsonargparse
-
 from online.main import main
 
 
@@ -32,64 +25,11 @@ def build_parser():
     return parser
 
 
-def configure_logging(logdir: Path, verbose: bool = False):
-    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    logging.basicConfig(
-        format=log_format,
-        level=logging.DEBUG if verbose else logging.INFO,
-        stream=sys.stdout,
-    )
-
-    logger = logging.getLogger()
-
-    # set logging to use UTC time
-    logging.Formatter.converter = lambda *args: datetime.now(
-        tz=timezone.utc
-    ).timetuple()
-
-    timestamp = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
-    run_log_dir = logdir / timestamp
-    run_log_dir.mkdir(exist_ok=True, parents=True)
-
-    # set up the timed rotating file handler
-    formatter = logging.Formatter(log_format)
-
-    # ensure formatter also uses UTC time
-    formatter.converter = lambda *args: datetime.now(
-        tz=timezone.utc
-    ).timetuple()
-
-    log_file = run_log_dir / "online.log"
-
-    # create a timed rotating file handler
-    handler = TimedRotatingFileHandler(
-        filename=log_file,
-        when="midnight",
-        backupCount=0,
-        utc=True,
-    )
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-    logger.info(f"Logging initialized in directory: {run_log_dir}")
-
-    # matplotlib and h5py have some debug-level logging
-    logging.getLogger("matplotlib").setLevel(logging.WARNING)
-    logging.getLogger("h5py").setLevel(logging.WARNING)
-
-
 def cli(args=None):
     parser = build_parser()
     args = parser.parse_args(args)
-    # create a new log directory each time we start using the current UTC time
-    logdir = args.outdir / "logs"
-    logdir.mkdir(exist_ok=True, parents=True)
-
-    configure_logging(logdir, args.verbose)
-
     args.pop("config")
     args = parser.instantiate_classes(args)
-
     main(**vars(args))
 
 

--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -471,7 +471,11 @@ def main(
             If true, autheticate with debug flag set
     """
 
-    log_queue = setup_logging(outdir / "logs", verbose=verbose)
+    subprocesses = []
+    log_queue, logging_subprocess = setup_logging(
+        outdir / "logs", verbose=verbose
+    )
+    subprocesses.append(logging_subprocess)
     level = logging.DEBUG if verbose else logging.INFO
 
     if emails is not None:
@@ -539,8 +543,6 @@ def main(
     pastro_queue = Queue()
     event_queue = Queue()
     amplfi_queue = Queue()
-
-    subprocesses = []
 
     # subprocess for re-authenticating
     minsecs = MIN_VALID_LIFETIME + auth_refresh + 100

--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -559,9 +559,9 @@ def main(
         )
     args = (
         error_queue,
-        log_queue,
         level,
         "authenticate",
+        log_queue,
         auth_refresh,
         minsecs,
         verbose,
@@ -577,9 +577,9 @@ def main(
     # detection information like FAR to gdb
     args = (
         error_queue,
-        log_queue,
         level,
         "event creator",
+        log_queue,
         event_queue,
         gdb,
         outdir / "events",
@@ -601,9 +601,9 @@ def main(
 
     args = (
         error_queue,
-        log_queue,
         level,
         "amplfi",
+        log_queue,
         amplfi_queue,
         gdb,
         inference_params,
@@ -628,9 +628,9 @@ def main(
 
     args = (
         error_queue,
-        log_queue,
         level,
         "p_astro",
+        log_queue,
         pastro_queue,
         background_path,
         foreground_path,

--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -263,6 +263,7 @@ def search(
             in_spec = True
 
         # update our input buffer with latest strain data
+        logging.debug("Updating input buffer")
         input_buffer.update(X, t0)
 
         # we have a frame that is analysis ready,
@@ -272,14 +273,19 @@ def search(
 
         # update the snapshotter state and return
         # unfolded batch of overlapping windows
+        logging.debug("Updating snapshotter")
         batch, state = snapshotter(X[None], state)
 
         # whiten the batch, and analyze with aframe
+        logging.debug("Whitening data")
         whitened = whitener(batch)
+
+        logging.debug("Performing inference")
         y = aframe(whitened)[:, 0]
 
         # update our output buffer with the latest aframe output,
         # which will also automatically integrate the output
+        logging.debug("Updating output buffer")
         significance_outputs, timing_outputs = output_buffer.update(
             y.cpu(), t0
         )
@@ -289,6 +295,7 @@ def search(
         # search for events in the integrated output
         event = None
         if snapshotter.full_psd_present and hl_ready:
+            logging.debug("Searching for event...")
             event = searcher.search(
                 significance_outputs, timing_outputs, t0 + time_offset
             )

--- a/projects/online/online/subprocesses/__init__.py
+++ b/projects/online/online/subprocesses/__init__.py
@@ -7,3 +7,4 @@ from .utils import (
     signal_handler,
     run_subprocess_with_logging,
 )
+from .logger import logging_subprocess, setup_logging

--- a/projects/online/online/subprocesses/amplfi.py
+++ b/projects/online/online/subprocesses/amplfi.py
@@ -10,7 +10,7 @@ from .utils import subprocess_wrapper
 from online.utils.email_alerts import send_detection_email
 
 if TYPE_CHECKING:
-    from ligo.gracedb.rest import GraceDb
+    from online.utils.gdb import GraceDb
 
 logger = logging.getLogger("amplfi-subprocess")
 
@@ -28,6 +28,9 @@ def amplfi_subprocess(
     use_distance: bool = True,
 ):
     logger.info("amplfi subprocess initialized")
+    # override with subprocesses logger
+    gdb.logger = logger
+
     while True:
         arg = amplfi_queue.get()
         if isinstance(arg[0], Event):

--- a/projects/online/online/subprocesses/events.py
+++ b/projects/online/online/subprocesses/events.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from .utils import subprocess_wrapper
 
 if TYPE_CHECKING:
-    from ligo.gracedb.rest import GraceDb
+    from online.utils.gdb import GraceDb
 
 logger = logging.getLogger("event-creation-subprocess")
 
@@ -21,6 +21,8 @@ def event_creation_subprocess(
 ):
     logger.info("event creation subprocess initialized")
 
+    # override with subprocesses logger
+    gdb.logger = logger
     while True:
         event = event_queue.get()
         logger.debug("Putting event in pastro queue")

--- a/projects/online/online/subprocesses/logger.py
+++ b/projects/online/online/subprocesses/logger.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def configure_logging(logdir: Path, verbose: bool = False):
+def configure_logging(logdir: "Path", verbose: bool = False):
     log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
     logging.basicConfig(
@@ -58,7 +58,7 @@ def configure_logging(logdir: Path, verbose: bool = False):
     logging.getLogger("h5py").setLevel(logging.WARNING)
 
 
-def logging_subprocess(queue: Queue, log_dir: Path, verbose: bool = False):
+def logging_subprocess(queue: Queue, log_dir: "Path", verbose: bool = False):
     """
     Logging subprocess that will be started in a separate Process.
     Ingests and processes logs from a `Queue` that is populated via
@@ -79,7 +79,7 @@ def logging_subprocess(queue: Queue, log_dir: Path, verbose: bool = False):
             traceback.print_exc(file=sys.stderr)
 
 
-def setup_logging(log_dir: Path, verbose: bool = True) -> Queue:
+def setup_logging(log_dir: "Path", verbose: bool = True) -> Queue:
     """
     Called in the main thread to setup a logging queue and
     initiate the logging subprocess
@@ -94,7 +94,7 @@ def setup_logging(log_dir: Path, verbose: bool = True) -> Queue:
     # logger subprocess
     log_queue = Queue()
 
-    listener = Process(target=logging_subprocess, args=(log_queue))
+    listener = Process(target=logging_subprocess, args=(log_queue, log_dir))
     listener.start()
 
     h = QueueHandler(log_queue)

--- a/projects/online/online/subprocesses/logger.py
+++ b/projects/online/online/subprocesses/logger.py
@@ -56,6 +56,7 @@ def configure_logging(logdir: "Path", verbose: bool = False):
     # matplotlib and h5py have some debug-level
     # logging we want to suppress
     logging.getLogger("matplotlib").setLevel(logging.WARNING)
+    logging.getLogger("matplotlib.font_manager").setLevel(logging.WARNING)
     logging.getLogger("h5py").setLevel(logging.WARNING)
 
 

--- a/projects/online/online/subprocesses/logger.py
+++ b/projects/online/online/subprocesses/logger.py
@@ -79,7 +79,9 @@ def logging_subprocess(queue: Queue, log_dir: "Path", verbose: bool = False):
             traceback.print_exc(file=sys.stderr)
 
 
-def setup_logging(log_dir: "Path", verbose: bool = True) -> Queue:
+def setup_logging(
+    log_dir: "Path", verbose: bool = True
+) -> tuple[Queue, Process]:
     """
     Called in the main thread to setup a logging queue and
     initiate the logging subprocess
@@ -102,4 +104,4 @@ def setup_logging(log_dir: "Path", verbose: bool = True) -> Queue:
     root.addHandler(h)
     root.setLevel(verbose)
 
-    return log_queue
+    return log_queue, listener

--- a/projects/online/online/subprocesses/logger.py
+++ b/projects/online/online/subprocesses/logger.py
@@ -1,0 +1,105 @@
+from typing import TYPE_CHECKING
+import logging
+from logging.handlers import TimedRotatingFileHandler, QueueHandler
+from datetime import datetime, timezone
+import sys
+from multiprocessing import Process, Queue
+
+if TYPE_CHECKING:
+    from multiprocessing import Queue
+    from pathlib import Path
+
+
+def configure_logging(logdir: Path, verbose: bool = False):
+    log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+    logging.basicConfig(
+        format=log_format,
+        level=logging.DEBUG if verbose else logging.INFO,
+        stream=sys.stdout,
+    )
+
+    logger = logging.getLogger()
+
+    # set logging to use UTC time
+    logging.Formatter.converter = lambda *args: datetime.now(
+        tz=timezone.utc
+    ).timetuple()
+
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    run_log_dir = logdir / timestamp
+    run_log_dir.mkdir(exist_ok=True, parents=True)
+
+    # set up the timed rotating file handler
+    formatter = logging.Formatter(log_format)
+
+    # ensure formatter also uses UTC time
+    formatter.converter = lambda *args: datetime.now(
+        tz=timezone.utc
+    ).timetuple()
+
+    log_file = run_log_dir / "online.log"
+
+    # create a timed rotating file handler
+    handler = TimedRotatingFileHandler(
+        filename=log_file,
+        when="midnight",
+        backupCount=0,
+        utc=True,
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    logger.info(f"Logging initialized in directory: {run_log_dir}")
+
+    # matplotlib and h5py have some debug-level
+    # logging we want to suppress
+    logging.getLogger("matplotlib").setLevel(logging.WARNING)
+    logging.getLogger("h5py").setLevel(logging.WARNING)
+
+
+def logging_subprocess(queue: Queue, log_dir: Path, verbose: bool = False):
+    """
+    Logging subprocess that will be started in a separate Process.
+    Ingests and processes logs from a `Queue` that is populated via
+    many separate subprocesses
+    """
+    configure_logging(log_dir, verbose)
+    while True:
+        try:
+            record = queue.get()
+            if record is None:
+                break
+            logger = logging.getLogger(record.name)
+            logger.handle(record)
+        except Exception:
+            import sys
+            import traceback
+
+            traceback.print_exc(file=sys.stderr)
+
+
+def setup_logging(log_dir: Path, verbose: bool = True) -> Queue:
+    """
+    Called in the main thread to setup a logging queue and
+    initiate the logging subprocess
+    """
+
+    # create a new base log directory each time
+    # we start using the current UTC time
+    log_dir.mkdir(exist_ok=True, parents=True)
+
+    # queue which will ingest logging records
+    # from subprocesses, and pass them to main
+    # logger subprocess
+    log_queue = Queue()
+
+    listener = Process(target=logging_subprocess, args=(log_queue))
+    listener.start()
+
+    h = QueueHandler(log_queue)
+    root = logging.getLogger()
+    root.addHandler(h)
+    root.setLevel(verbose)
+
+    return log_queue

--- a/projects/online/online/subprocesses/logger.py
+++ b/projects/online/online/subprocesses/logger.py
@@ -68,17 +68,11 @@ def logging_subprocess(queue: Queue, log_dir: "Path", verbose: bool = False):
     """
     configure_logging(log_dir, verbose)
     while True:
-        try:
-            record = queue.get()
-            if record is None:
-                break
-            logger = logging.getLogger(record.name)
-            logger.handle(record)
-        except Exception:
-            import sys
-            import traceback
-
-            traceback.print_exc(file=sys.stderr)
+        record = queue.get()
+        if record is None:
+            break
+        logger = logging.getLogger(record.name)
+        logger.handle(record)
 
 
 def setup_logging(

--- a/projects/online/online/subprocesses/p_astro.py
+++ b/projects/online/online/subprocesses/p_astro.py
@@ -15,7 +15,7 @@ from p_astro.foreground import KdeForeground
 from p_astro.p_astro import Pastro
 
 if TYPE_CHECKING:
-    from ligo.gracedb.rest import GraceDb
+    from online.utils.gdb import GraceDb
 
 logger = logging.getLogger("pastro-process")
 
@@ -83,6 +83,9 @@ def pastro_subprocess(
     outdir: Path,
 ):
     logger.info("pastro subprocess initialized")
+
+    # override with subprocesses logger
+    gdb.logger = logger
     pastro_model = fit_or_load_pastro(
         outdir / "pastro.pkl",
         background_path,

--- a/projects/online/online/subprocesses/utils.py
+++ b/projects/online/online/subprocesses/utils.py
@@ -1,7 +1,8 @@
 import logging
 import sys
+from logging.handlers import QueueHandler
 from multiprocessing import Process, Queue
-from typing import List
+from typing import Union
 import traceback
 import subprocess
 
@@ -11,10 +12,23 @@ def subprocess_wrapper(
 ):
     """
     Wraps a callable so that errors are propogated
-    into a queue object
+    into a queue object, and logs are passed to a log_queue
+    object for downstream handling by logger subprocess
     """
 
-    def wrapper(error_queue: Queue, name: str, *args, **kwargs):
+    def wrapper(
+        error_queue: Queue,
+        log_queue: Queue,
+        level: Union[int, str],
+        name: str,
+        *args,
+        **kwargs,
+    ):
+        h = QueueHandler(log_queue)
+        root = logging.getLogger(name)
+        root.addHandler(h)
+        root.setLevel(level)
+
         try:
             f(*args, **kwargs)
         except Exception as e:
@@ -25,7 +39,7 @@ def subprocess_wrapper(
 
 
 def cleanup_subprocesses(
-    subprocesses: List[Process],
+    subprocesses: list[Process],
 ):
     """
     Terminate and clean up subprocesses if the
@@ -56,7 +70,7 @@ def signal_handler(signum, frame):
 
 
 def run_subprocess_with_logging(
-    args: List[str], logger=None, log_stderr_on_success=False
+    args: list[str], logger=None, log_stderr_on_success=False
 ):
     """
     Run a subprocess, logging stdout via a python logger

--- a/projects/online/online/subprocesses/utils.py
+++ b/projects/online/online/subprocesses/utils.py
@@ -24,8 +24,11 @@ def subprocess_wrapper(
         *args,
         **kwargs,
     ):
+        # add a queue handler to the root logger;
+        # in python logging, any child loggers
+        # will by default inherit the parent logger handler
         h = QueueHandler(log_queue)
-        root = logging.getLogger(name)
+        root = logging.getLogger()
         root.addHandler(h)
         root.setLevel(level)
 

--- a/projects/online/online/subprocesses/utils.py
+++ b/projects/online/online/subprocesses/utils.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from logging.handlers import QueueHandler
 from multiprocessing import Process, Queue
-from typing import Union
+from typing import Union, Optional
 import traceback
 import subprocess
 
@@ -18,19 +18,20 @@ def subprocess_wrapper(
 
     def wrapper(
         error_queue: Queue,
-        log_queue: Queue,
         level: Union[int, str],
         name: str,
+        log_queue: Optional[Queue],
         *args,
         **kwargs,
     ):
         # add a queue handler to the root logger;
         # in python logging, any child loggers
         # will by default inherit the parent logger handler
-        h = QueueHandler(log_queue)
-        root = logging.getLogger()
-        root.addHandler(h)
-        root.setLevel(level)
+        if log_queue is not None:
+            h = QueueHandler(log_queue)
+            root = logging.getLogger()
+            root.addHandler(h)
+            root.setLevel(level)
 
         try:
             f(*args, **kwargs)

--- a/projects/online/online/subprocesses/utils.py
+++ b/projects/online/online/subprocesses/utils.py
@@ -30,6 +30,9 @@ def subprocess_wrapper(
         if log_queue is not None:
             h = QueueHandler(log_queue)
             root = logging.getLogger()
+            # clear already inherited handlers so
+            # duplicate logs arent sent
+            root.handlers.clear()
             root.addHandler(h)
             root.setLevel(level)
 

--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -111,7 +111,7 @@ class GraceDb(_GraceDb):
         event_dir: Path,
     ):
         event_dir = self.write_dir / event_dir
-        skymap_fname = event_dir / "amplfi.multiorder.fits"
+        skymap_fname = event_dir / "amplfi.fits"
         skymap.writeto(skymap_fname)
 
         self.logger.debug("Submitting skymap to GraceDB")

--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Literal
+from typing import TYPE_CHECKING, List, Literal, Optional
 import bilby
 import h5py
 from gwpy.time import tconvert
@@ -27,12 +27,25 @@ class GraceDb(_GraceDb):
         write_dir:
             Local directory where event data will be written
             upon submission
+        logger:
+            Optional logger object to emit logs
     """
 
-    def __init__(self, *args, server: GdbServer, write_dir: Path, **kwargs):
+    def __init__(
+        self,
+        *args,
+        server: GdbServer,
+        write_dir: Path,
+        logger: Optional[logging.Logger] = None,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs, use_auth="scitoken")
         self.server = server
         self.write_dir = write_dir
+        if logger is None:
+            self.logger = logging.getLogger()
+        else:
+            self.logger = logger
 
     def url(self, graceid):
         if self.server in ["playground", "test"]:
@@ -47,10 +60,10 @@ class GraceDb(_GraceDb):
         return gracedb_url
 
     def submit(self, event: Event):
-        logging.info(f"Submitting trigger to file {event.filename}")
+        self.logger.info(f"Submitting trigger to file {event.filename}")
         event_dir = self.write_dir / event.event_dir
         filename = event_dir / event.filename
-        logging.info("Creating event in GraceDB")
+        self.logger.info("Creating event in GraceDB")
         response = self.create_event(
             group="CBC",
             pipeline="aframe",
@@ -58,7 +71,7 @@ class GraceDb(_GraceDb):
             search="AllSky",
         )
 
-        logging.debug("Event created")
+        self.logger.debug("Event created")
 
         # Get the event's graceid for submitting
         # further data products
@@ -98,10 +111,10 @@ class GraceDb(_GraceDb):
         event_dir: Path,
     ):
         event_dir = self.write_dir / event_dir
-        skymap_fname = event_dir / "amplfi.fits"
+        skymap_fname = event_dir / "amplfi.multiorder.fits"
         skymap.writeto(skymap_fname)
 
-        logging.debug("Submitting skymap to GraceDB")
+        self.logger.debug("Submitting skymap to GraceDB")
         self.write_log(
             graceid,
             "skymap",
@@ -109,7 +122,7 @@ class GraceDb(_GraceDb):
             tag_name="sky_loc",
             label="SKYMAP_READY",
         )
-        logging.debug("Skymap submitted")
+        self.logger.debug("Skymap submitted")
 
         # Write posterior samples to file, adhering to expected format
         filename = event_dir / "amplfi.posterior_samples.hdf5"
@@ -128,11 +141,11 @@ class GraceDb(_GraceDb):
             filename=corner_fname,
         )
 
-        logging.debug("Submitting corner plot to GraceDB")
+        self.logger.debug("Submitting corner plot to GraceDB")
         self.write_log(
             graceid, "Corner plot", filename=corner_fname, tag_name="pe"
         )
-        logging.debug("Corner plot submitted")
+        self.logger.debug("Corner plot submitted")
 
     def submit_ligo_skymap_from_samples(
         self,
@@ -173,7 +186,9 @@ class GraceDb(_GraceDb):
         # advantage of this
 
         # run subprocess, passing any output to python logger
-        result = run_subprocess_with_logging(args, log_stderr_on_success=True)
+        result = run_subprocess_with_logging(
+            args, logger=self.logger, log_stderr_on_success=True
+        )
 
         self.write_log(
             graceid,

--- a/projects/online/online/utils/pe.py
+++ b/projects/online/online/utils/pe.py
@@ -16,7 +16,7 @@ from torch.distributions import Uniform
 torch.set_num_threads(1)
 
 if TYPE_CHECKING:
-    from amplfi.train.architectures.flows.base import FlowArchitecture
+    from amplfi.train.architectures.flows import FlowArchitecture
     from ml4gw.transforms import ChannelWiseScaler, SpectralDensity, Whiten
 
 


### PR DESCRIPTION
- Implements https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes to avoid things like race conditions when logging to a single file from multiple processes

@wbenoit26 this seems to be working fine. Going to launch on O3 MDC. Will probably have to wait a bit to see if it resolve the logging issue  