### PR TITLE
Online updates

### DIFF
--- a/projects/online/config.yaml
+++ b/projects/online/config.yaml
@@ -69,6 +69,8 @@ refractory_period: 8
 far_threshold: 1 # per day
 email_far_threshold: 0.00000001 # Hz
 emails: null
+nside: 64
+min_samples_per_pix: 5
 server: "local"
 auth_refresh: 300
 ifo_suffix: 

--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -359,7 +359,8 @@ def main(
     emails: Optional[list[str]] = None,
     email_far_threshold: float = 1e-6,
     auth_refresh: int = 9600,
-    nside: int = 32,
+    nside: int = 64,
+    min_samples_per_pix: int = 5,
     use_distance: bool = True,
     device: str = "cpu",
     verbose: bool = False,
@@ -460,6 +461,10 @@ def main(
         auth_refresh:
             Number of seconds between calls to authenticate,
             that refreshes the scitoken credential
+        min_samples_per_pix:
+            Minimum number of samples per healpix pixel
+            required to estimate parameters of the distance
+            ansatz
         nside:
             Healpix resolution for low-latency skymaps
         use_distance:
@@ -584,6 +589,7 @@ def main(
         emails,
         email_far_threshold,
         nside,
+        min_samples_per_pix,
         use_distance,
     )
 

--- a/projects/online/online/subprocesses/amplfi.py
+++ b/projects/online/online/subprocesses/amplfi.py
@@ -24,7 +24,8 @@ def amplfi_subprocess(
     shared_samples: Array,
     emails: Optional[list[str]] = None,
     email_far_threshold: float = 1e-6,
-    nside: int = 32,
+    nside: int = 64,
+    min_samples_per_pix: int = 5,
     use_distance: bool = True,
 ):
     logger.info("amplfi subprocess initialized")
@@ -44,7 +45,9 @@ def amplfi_subprocess(
             )
 
             logger.info("Creating low resolution skymap")
-            skymap = result.to_skymap(nside, use_distance=use_distance)
+            skymap = result.to_skymap(
+                nside, min_samples_per_pix, use_distance=use_distance
+            )
             fits_skymap = io.fits.table_to_hdu(skymap)
 
             graceid = amplfi_queue.get()

--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -111,6 +111,9 @@ class GraceDb(_GraceDb):
         )
         logging.debug("Skymap submitted")
 
+        # rename so we can later write kde file
+        skymap_fname.rename(event_dir / "amplfi.multiorder.fits,0")
+
         # Write posterior samples to file, adhering to expected format
         filename = event_dir / "amplfi.posterior_samples.hdf5"
         posterior_df = result.posterior
@@ -187,8 +190,8 @@ class GraceDb(_GraceDb):
         plt.switch_backend("agg")
 
         event_dir = self.write_dir / event_dir
-        amplfi_fname = str(event_dir / "amplfi.flattened.png")
-        ligo_skymap_fname = str(event_dir / "amplfi.multiorder.png")
+        amplfi_fname = str(event_dir / "amplfi.histogram.png")
+        ligo_skymap_fname = str(event_dir / "amplfi.kde.png")
 
         ligo_skymap_plot(
             [

--- a/projects/online/online/utils/gdb.py
+++ b/projects/online/online/utils/gdb.py
@@ -98,7 +98,7 @@ class GraceDb(_GraceDb):
         event_dir: Path,
     ):
         event_dir = self.write_dir / event_dir
-        skymap_fname = event_dir / "amplfi.fits"
+        skymap_fname = event_dir / "amplfi.multiorder.fits"
         skymap.writeto(skymap_fname)
 
         logging.debug("Submitting skymap to GraceDB")

--- a/projects/online/online/utils/pe.py
+++ b/projects/online/online/utils/pe.py
@@ -16,7 +16,7 @@ from torch.distributions import Uniform
 torch.set_num_threads(1)
 
 if TYPE_CHECKING:
-    from amplfi.train.architectures.flows.base import FlowArchitecture
+    from amplfi.train.architectures.flows import FlowArchitecture
     from ml4gw.transforms import ChannelWiseScaler, SpectralDensity, Whiten
 
 


### PR DESCRIPTION
- Add `min_samples_per_pix` variable and set default to 5
- Change `nside` default to 64
- Upload both skymaps as `amplfi.multiorder.fits` - after submitting first histogram skymap, rename file to  `amplfi.multiorder.fits,0` so its not overwritten by kde