### PR TITLE
Update `in_spec` to False when frames aren't ready

### DIFF
--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -197,6 +197,8 @@ def search(
         virgo_ready.append(ready[-1])
         virgo_ready.pop(0)
         if not hl_ready:
+            in_spec = False
+
             if searcher.detecting:
                 # if we were in the middle of a detection,
                 # we won't get to see the peak of the event


### PR DESCRIPTION
We never set the `in_spec` flag when frames aren't ready, so we weren't resetting the states of the snapshotter and buffers when re-entering analysis-ready mode.