### PR TITLE
Event rate bug

### DIFF
--- a/projects/online/online/monitor/utils/parse_logs.py
+++ b/projects/online/online/monitor/utils/parse_logs.py
@@ -95,12 +95,12 @@ def estimate_tb(run_dir: Path, start_time: float) -> float:
     return get_tb_from_log_text(log_text, start_time)
 
 
-def pipeline_online(expected_process_count: int = 6):
+def pipeline_online():
     online_processes = 0
     for p in psutil.process_iter(["username", "name"]):
         if p.info["username"] == "aframe" and p.info["name"] == "online":
             online_processes += 1
-    return online_processes == expected_process_count
+    return online_processes > 1
 
 
 def data_ready(run_dir: Path):

--- a/projects/online/online/monitor/utils/plotting.py
+++ b/projects/online/online/monitor/utils/plotting.py
@@ -207,22 +207,30 @@ def event_rate_plots(plotsdir: Path, df: pd.DataFrame) -> None:
         warnings.simplefilter("ignore", category=UserWarning)
         past_day = past_day.tz_convert(timezone.utc)
         past_week = past_week.tz_convert(timezone.utc)
-        past_day.resample("1h").size().plot()
-        plt.xlabel("Time")
-        plt.ylabel("Events per hour")
-        plt.savefig(
-            plotsdir / "event_rate_past_day.png", dpi=150, bbox_inches="tight"
-        )
-        plt.close()
+        if len(past_day) > 0:
+            past_day.resample("1h").size().plot()
+            plt.xlabel("Time")
+            plt.ylabel("Events per hour")
+            plt.savefig(
+                plotsdir / "event_rate_past_day.png",
+                dpi=150,
+                bbox_inches="tight",
+            )
+            plt.close()
 
-        past_week.resample("4h").size().plot()
-        plt.xlabel("Time")
-        plt.ylabel("Events per 4 hours")
-        plt.savefig(
-            plotsdir / "event_rate_past_week.png", dpi=150, bbox_inches="tight"
-        )
-        plt.close()
+        if len(past_week) > 0:
+            past_week.resample("4h").size().plot()
+            plt.xlabel("Time")
+            plt.ylabel("Events per 4 hours")
+            plt.savefig(
+                plotsdir / "event_rate_past_week.png",
+                dpi=150,
+                bbox_inches="tight",
+            )
+            plt.close()
 
+        # If this plotting function is getting called, df will always have
+        # at least one entry
         df.resample("1d").size().plot()
         plt.xlabel("Time")
         plt.ylabel("Events per day")

--- a/projects/online/online/monitor/utils/plotting.py
+++ b/projects/online/online/monitor/utils/plotting.py
@@ -209,25 +209,29 @@ def event_rate_plots(plotsdir: Path, df: pd.DataFrame) -> None:
         past_week = past_week.tz_convert(timezone.utc)
         if len(past_day) > 0:
             past_day.resample("1h").size().plot()
-            plt.xlabel("Time")
-            plt.ylabel("Events per hour")
-            plt.savefig(
-                plotsdir / "event_rate_past_day.png",
-                dpi=150,
-                bbox_inches="tight",
-            )
-            plt.close()
+        else:
+            plt.figure()
+        plt.xlabel("Time")
+        plt.ylabel("Events per hour")
+        plt.savefig(
+            plotsdir / "event_rate_past_day.png",
+            dpi=150,
+            bbox_inches="tight",
+        )
+        plt.close()
 
         if len(past_week) > 0:
             past_week.resample("4h").size().plot()
-            plt.xlabel("Time")
-            plt.ylabel("Events per 4 hours")
-            plt.savefig(
-                plotsdir / "event_rate_past_week.png",
-                dpi=150,
-                bbox_inches="tight",
-            )
-            plt.close()
+        else:
+            plt.figure()
+        plt.xlabel("Time")
+        plt.ylabel("Events per 4 hours")
+        plt.savefig(
+            plotsdir / "event_rate_past_week.png",
+            dpi=150,
+            bbox_inches="tight",
+        )
+        plt.close()
 
         # If this plotting function is getting called, df will always have
         # at least one entry


### PR DESCRIPTION
Creates blank plots for the case when there hasn't been an event in the past day/week. Also makes the check for the search being online less restrictive to allow to variable numbers of subprocesses. If at least 2 `online` processes are running, I think it's reasonable to assume the search is active.