### PR TITLE
Add top-k support to heterodyne functionality

### DIFF
--- a/libs/architectures/architectures/supervised.py
+++ b/libs/architectures/architectures/supervised.py
@@ -301,13 +301,17 @@ class SupervisedHeterodyneTimeDomainResNet(SupervisedArchitecture):
         zero_init_residual: bool = False,
         groups: int = 1,
         width_per_group: int = 64,
+        top_k: int | None = None,
         stride_type: Optional[list[Literal["stride", "dilation"]]] = None,
         norm_layer: Optional[NormLayer] = None,
         **kwargs,
     ) -> None:
         super().__init__()
+
+        num_channels = top_k if top_k is not None else num_chirp_masses
+
         self.time_domain_resnet = ResNet1D(
-            in_channels=num_ifos * num_chirp_masses,
+            in_channels=num_ifos * num_channels,
             layers=layers,
             classes=1,
             kernel_size=kernel_size,

--- a/libs/utils/tests/test_preprocessing.py
+++ b/libs/utils/tests/test_preprocessing.py
@@ -8,6 +8,7 @@ from utils.preprocessing import (
 from utils.augmentation import HeterodyneAugmentor
 from ml4gw.transforms import Heterodyne
 import torch
+import torch.nn.functional as F
 import pytest
 
 
@@ -299,6 +300,84 @@ class TestBatchWhitener:
         kernels_heterodyned = heterodyne(whitener(x))
         _B, _C, _M, _T = kernels_heterodyned.shape
         kernels = kernels_heterodyned.reshape(_B, _C * _M, _T)
+        kernels_aug = whitener_aug(x)
+        assert torch.allclose(kernels_aug, kernels)
+
+    def test_with_heterodyne_augmentor_top_k(self):
+
+        heterodyne_augmentor = HeterodyneAugmentor(
+            sample_rate=self.sample_rate,
+            kernel_length=self.kernel_length,
+            chirp_mass_low=1.0,
+            chirp_mass_high=2.5,
+            num_chirp_masses=10,
+            chirp_mass_spacing="log",
+            keep_last_n_seconds=1.5,
+            top_k=5,
+        )
+
+        whitener = BatchWhitener(
+            kernel_length=self.kernel_length,
+            sample_rate=self.sample_rate,
+            inference_sampling_rate=self.inference_sampling_rate,
+            batch_size=self.batch_size,
+            fduration=self.fduration,
+            fftlength=self.fftlength,
+        )
+
+        whitener_aug = BatchWhitener(
+            kernel_length=self.kernel_length,
+            sample_rate=self.sample_rate,
+            inference_sampling_rate=self.inference_sampling_rate,
+            batch_size=self.batch_size,
+            fduration=self.fduration,
+            fftlength=self.fftlength,
+            augmentor=heterodyne_augmentor,
+        )
+
+        channels = 2
+        total_samples = int(
+            (
+                (self.batch_size - 1) * whitener_aug.stride_size
+                + whitener_aug.kernel_size
+            )
+            * 2
+        )
+
+        x = torch.randn(channels, total_samples)
+
+        heterodyne = Heterodyne(
+            sample_rate=self.sample_rate,
+            kernel_length=self.kernel_length,
+            chirp_mass=heterodyne_augmentor.chirp_mass_grid,
+            return_type="time",
+        )
+
+        kernels = whitener_aug(x)
+
+        kernels_heterodyned = heterodyne(whitener(x))
+        _B, _C, _M, _T = kernels_heterodyned.shape
+        avgpool = F.avg_pool1d(
+            torch.abs(kernels_heterodyned.reshape(_B, _C * _M, _T)),
+            31,
+            stride=1,
+            padding=15,
+        ).reshape(_B, _C, _M, _T)
+        avgpool_snr = torch.sqrt(
+            (avgpool[..., -int(1.5 * self.sample_rate) :] ** 2).sum(dim=1)
+        )
+        vals = torch.max(avgpool_snr, dim=-1).values
+        idx = torch.topk(vals, k=5, dim=-1).indices
+        idx_expand = idx[:, None, :, None].expand(-1, _C, -1, _T)
+        kernels_heterodyned = torch.gather(
+            kernels_heterodyned, dim=2, index=idx_expand
+        )
+        kernels_heterodyned = kernels_heterodyned.reshape(_B, _C * 5, _T)
+        kernels_heterodyned = kernels_heterodyned[
+            ..., -int(1.5 * self.sample_rate) :
+        ]
+        kernels = kernels_heterodyned
+
         kernels_aug = whitener_aug(x)
         assert torch.allclose(kernels_aug, kernels)
 

--- a/libs/utils/utils/augmentation.py
+++ b/libs/utils/utils/augmentation.py
@@ -7,6 +7,78 @@ from typing import Literal
 from ml4gw.transforms import Heterodyne
 
 
+class SelectTopK(torch.nn.Module):
+    """
+    Select top `k` chirp mass channels are chosen from `M` heterodyned
+    timeseries. The input is expected to have shape `(B, C, M, T)`,
+    where `B` is the batch size, `C` is the number of detector channels,
+    `M` is the number of chirp mass channels, and `T` is the number of
+    time samples.
+
+    Args:
+        kernel_size (int):
+            Size of the running average (average pooling) window used to
+            smooth the absolute value of the input before computing the
+            selection statistic.
+        stride (int):
+            Stride of the average pooling operation.
+        padding (int):
+            Zero-padding applied to both sides of the timeseries before
+            the average pooling operation.
+        keep_last_n_samples (int, optional):
+            If provided, only the final `n` samples are used when
+            computing the statistic used to select the top k chirp mass
+            channels. If `None`, all samples are used.
+        top_k (int):
+            Number of chirp mass channels to retain. If `None`, all
+            chirp mass channels are retained and the `M` dimension is
+            flattened into the channel dimension.
+    """
+
+    def __init__(
+        self,
+        top_k: int,
+        kernel_size: int = 31,
+        stride: int = 1,
+        padding: int = 15,
+        keep_last_n_samples: int | None = None,
+    ):
+        super().__init__()
+
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
+        self.keep_last_n_samples = keep_last_n_samples
+        self.top_k = top_k
+
+    def forward(self, X):
+        B, C, M, T = X.shape
+
+        avgpool = torch.stack(
+            [
+                F.avg_pool1d(
+                    torch.abs(x.reshape(C * M, T)),
+                    kernel_size=self.kernel_size,
+                    stride=self.stride,
+                    padding=self.padding,
+                )
+                for x in X
+            ]
+        ).reshape(B, C, M, T)
+
+        if self.keep_last_n_samples is not None:
+            avgpool_snr = torch.sqrt(
+                (avgpool[..., -self.keep_last_n_samples :] ** 2).sum(dim=1)
+            )
+        else:
+            avgpool_snr = torch.sqrt((avgpool**2).sum(dim=1))
+
+        vals = avgpool_snr.max(dim=-1).values
+        idx = torch.topk(vals, k=self.top_k, dim=-1).indices
+        idx = idx[:, None, :, None].expand(B, C, self.top_k, T)
+        return torch.gather(X, dim=2, index=idx).reshape(B, C * self.top_k, T)
+
+
 class HeterodyneAugmentor(torch.nn.Module):
     """
     Apply a heterodyne transform over a grid of chirp masses to a batch
@@ -28,9 +100,9 @@ class HeterodyneAugmentor(torch.nn.Module):
             If provided, only the last `n` seconds of the kernel_length are
             returned. Otherwise, the full kernel_length is returned.
         top_k (int):
-            If provided, only the top `k` chirp mass channels are chosen
-            for the heterodyned timeseries. Otherwise, all chirp mass
-            channels are returned.
+            If provided, the top `k` chirp mass channels are selected based on
+            their absolute amplitude, corresponding to the `k` matching chirp
+            masses with. If `None`, all chirp mass channels are returned.
     Shape:
         Input: (batch_size, channels, time)
         Output: (batch_size, channels * num_chirp_masses, time_out)
@@ -63,13 +135,12 @@ class HeterodyneAugmentor(torch.nn.Module):
         chirp_mass_high: float = 2.5,
         num_chirp_masses: int = 100,
         chirp_mass_spacing: Literal["linear", "log"] = "log",
-        keep_last_n_seconds: float = None,
-        top_k: int = None,
+        keep_last_n_seconds: float | None = None,
+        top_k: int | None = None,
     ):
         super().__init__()
         self.sample_rate = sample_rate
         self.kernel_length = kernel_length
-        self.keep_last_n_seconds = keep_last_n_seconds
         self.top_k = top_k
         self.num_chirp_masses = num_chirp_masses
         self.keep_last_n_seconds = keep_last_n_seconds
@@ -85,6 +156,8 @@ class HeterodyneAugmentor(torch.nn.Module):
             self.keep_last_n_samples = int(
                 self.keep_last_n_seconds * sample_rate
             )
+        else:
+            self.keep_last_n_samples = None
 
         self.heterodyne_transform = Heterodyne(
             sample_rate=sample_rate,
@@ -92,6 +165,12 @@ class HeterodyneAugmentor(torch.nn.Module):
             chirp_mass=self.chirp_mass_grid,
             return_type="time",
         )
+
+        if self.top_k is not None:
+            self.select_top_k = SelectTopK(
+                keep_last_n_samples=self.keep_last_n_samples,
+                top_k=self.top_k,
+            )
 
     def _create_chirp_mass_grid(
         self,
@@ -133,27 +212,9 @@ class HeterodyneAugmentor(torch.nn.Module):
             x_heterodyned = torch.empty((_B, _C * self.num_chirp_masses, _T))
         # Heterodyne the whitened timeseries
         x = self.heterodyne_transform(x)
-        #
         if self.top_k is not None:
-            avgpool = F.avg_pool1d(
-                torch.abs(x.reshape(_B, _C * self.num_chirp_masses, _T)),
-                31,
-                stride=1,
-                padding=15,
-            ).reshape(_B, _C, self.num_chirp_masses, _T)
-            if self.keep_last_n_seconds is not None:
-                avgpool_snr = torch.sqrt(
-                    (avgpool[..., -self.keep_last_n_samples :] ** 2).sum(dim=1)
-                )
-            else:
-                avgpool_snr = torch.sqrt((avgpool**2).sum(dim=1))
-            vals = torch.max(avgpool_snr, dim=-1).values
-            idx = torch.topk(vals, k=self.top_k, dim=-1).indices
-            idx_expand = idx[:, None, :, None].expand(-1, _C, -1, _T)
-            x = torch.gather(x, dim=2, index=idx_expand)
-            # Reshaping x from (batch_size, channels, top_k, kernel_size)
-            # to (batch_size, channels x top_k, kernel_size)
-            x = x.reshape(_B, _C * self.top_k, _T)
+            # Select the top k chirp mass channels
+            x = self.select_top_k(x)
         else:
             # Reshaping x from
             # (batch_size, channels, num_chirp_mass, kernel_size)

--- a/libs/utils/utils/augmentation.py
+++ b/libs/utils/utils/augmentation.py
@@ -7,15 +7,24 @@ from typing import Literal
 from ml4gw.transforms import Heterodyne
 
 
-class SelectTopK(torch.nn.Module):
+def select_top_k(
+    X: torch.Tensor,
+    top_k: int,
+    kernel_size: int = 31,
+    stride: int = 1,
+    padding: int = 15,
+    keep_last_n_samples: int | None = None,
+) -> torch.Tensor:
     """
-    Select top `k` chirp mass channels are chosen from `M` heterodyned
-    timeseries. The input is expected to have shape `(B, C, M, T)`,
-    where `B` is the batch size, `C` is the number of detector channels,
-    `M` is the number of chirp mass channels, and `T` is the number of
-    time samples.
+    Select top `k` chirp mass channels from `M` heterodyned timeseries.
 
     Args:
+        X (Tensor):
+            Input tensor of shape (B, C, M, T) where B is the batch
+            size, C is the number of channels, M is the number of chirp
+            mass channels, and T is the number of time samples.
+        top_k (int):
+            Number of chirp mass channels to retain.
         kernel_size (int):
             Size of the running average (average pooling) window used to
             smooth the absolute value of the input before computing the
@@ -29,54 +38,38 @@ class SelectTopK(torch.nn.Module):
             If provided, only the final `n` samples are used when
             computing the statistic used to select the top k chirp mass
             channels. If `None`, all samples are used.
-        top_k (int):
-            Number of chirp mass channels to retain. If `None`, all
-            chirp mass channels are retained and the `M` dimension is
-            flattened into the channel dimension.
+
+    Returns:
+        Tensor:
+            Output tensor of shape (B, C * top_k, T) containing the
+            selected top k chirp mass channels for each batch and channel.
     """
 
-    def __init__(
-        self,
-        top_k: int,
-        kernel_size: int = 31,
-        stride: int = 1,
-        padding: int = 15,
-        keep_last_n_samples: int | None = None,
-    ):
-        super().__init__()
+    B, C, M, T = X.shape
 
-        self.kernel_size = kernel_size
-        self.stride = stride
-        self.padding = padding
-        self.keep_last_n_samples = keep_last_n_samples
-        self.top_k = top_k
-
-    def forward(self, X):
-        B, C, M, T = X.shape
-
-        avgpool = torch.stack(
-            [
-                F.avg_pool1d(
-                    torch.abs(x.reshape(C * M, T)),
-                    kernel_size=self.kernel_size,
-                    stride=self.stride,
-                    padding=self.padding,
-                )
-                for x in X
-            ]
-        ).reshape(B, C, M, T)
-
-        if self.keep_last_n_samples is not None:
-            avgpool_snr = torch.sqrt(
-                (avgpool[..., -self.keep_last_n_samples :] ** 2).sum(dim=1)
+    avgpool = torch.stack(
+        [
+            F.avg_pool1d(
+                torch.abs(x.reshape(C * M, T)),
+                kernel_size=kernel_size,
+                stride=stride,
+                padding=padding,
             )
-        else:
-            avgpool_snr = torch.sqrt((avgpool**2).sum(dim=1))
+            for x in X
+        ]
+    ).reshape(B, C, M, T)
 
-        vals = avgpool_snr.max(dim=-1).values
-        idx = torch.topk(vals, k=self.top_k, dim=-1).indices
-        idx = idx[:, None, :, None].expand(B, C, self.top_k, T)
-        return torch.gather(X, dim=2, index=idx).reshape(B, C * self.top_k, T)
+    if keep_last_n_samples is not None:
+        avgpool_snr = torch.sqrt(
+            (avgpool[..., -keep_last_n_samples:] ** 2).sum(dim=1)
+        )
+    else:
+        avgpool_snr = torch.sqrt((avgpool**2).sum(dim=1))
+
+    vals = avgpool_snr.max(dim=-1).values
+    idx = torch.topk(vals, k=top_k, dim=-1).indices
+    idx = idx[:, None, :, None].expand(B, C, top_k, T)
+    return torch.gather(X, dim=2, index=idx).reshape(B, C * top_k, T)
 
 
 class HeterodyneAugmentor(torch.nn.Module):
@@ -166,12 +159,6 @@ class HeterodyneAugmentor(torch.nn.Module):
             return_type="time",
         )
 
-        if self.top_k is not None:
-            self.select_top_k = SelectTopK(
-                keep_last_n_samples=self.keep_last_n_samples,
-                top_k=self.top_k,
-            )
-
     def _create_chirp_mass_grid(
         self,
         chirp_mass_low: float,
@@ -214,7 +201,9 @@ class HeterodyneAugmentor(torch.nn.Module):
         x = self.heterodyne_transform(x)
         if self.top_k is not None:
             # Select the top k chirp mass channels
-            x = self.select_top_k(x)
+            x = select_top_k(
+                x, self.top_k, keep_last_n_samples=self.keep_last_n_samples
+            )
         else:
             # Reshaping x from
             # (batch_size, channels, num_chirp_mass, kernel_size)

--- a/libs/utils/utils/augmentation.py
+++ b/libs/utils/utils/augmentation.py
@@ -1,5 +1,6 @@
 import math
 import torch
+import torch.nn.functional as F
 from torch import Tensor
 from typing import Literal
 
@@ -26,6 +27,10 @@ class HeterodyneAugmentor(torch.nn.Module):
         keep_last_n_seconds (float):
             If provided, only the last `n` seconds of the kernel_length are
             returned. Otherwise, the full kernel_length is returned.
+        top_k (int):
+            If provided, only the top `k` chirp mass channels are chosen
+            for the heterodyned timeseries. Otherwise, all chirp mass
+            channels are returned.
     Shape:
         Input: (batch_size, channels, time)
         Output: (batch_size, channels * num_chirp_masses, time_out)
@@ -59,11 +64,13 @@ class HeterodyneAugmentor(torch.nn.Module):
         num_chirp_masses: int = 100,
         chirp_mass_spacing: Literal["linear", "log"] = "log",
         keep_last_n_seconds: float = None,
+        top_k: int = None,
     ):
         super().__init__()
         self.sample_rate = sample_rate
         self.kernel_length = kernel_length
         self.keep_last_n_seconds = keep_last_n_seconds
+        self.top_k = top_k
         self.num_chirp_masses = num_chirp_masses
         self.keep_last_n_seconds = keep_last_n_seconds
 
@@ -120,12 +127,38 @@ class HeterodyneAugmentor(torch.nn.Module):
                 or determined by `keep_last_n_seconds`.
         """
         _B, _C, _T = x.shape
-        x_heterodyned = torch.empty((_B, _C * self.num_chirp_masses, _T))
+        if self.top_k is not None:
+            x_heterodyned = torch.empty((_B, _C * self.top_k, _T))
+        else:
+            x_heterodyned = torch.empty((_B, _C * self.num_chirp_masses, _T))
         # Heterodyne the whitened timeseries
         x = self.heterodyne_transform(x)
-        # Reshaping x from (batch_size, channels, num_chirp_mass, kernel_size)
-        # to (batch_size, channels x num_chirp_mass, kernel_size)
-        x = x.reshape(_B, _C * self.num_chirp_masses, _T)
+        #
+        if self.top_k is not None:
+            avgpool = F.avg_pool1d(
+                torch.abs(x.reshape(_B, _C * self.num_chirp_masses, _T)),
+                31,
+                stride=1,
+                padding=15,
+            ).reshape(_B, _C, self.num_chirp_masses, _T)
+            if self.keep_last_n_seconds is not None:
+                avgpool_snr = torch.sqrt(
+                    (avgpool[..., -self.keep_last_n_samples :] ** 2).sum(dim=1)
+                )
+            else:
+                avgpool_snr = torch.sqrt((avgpool**2).sum(dim=1))
+            vals = torch.max(avgpool_snr, dim=-1).values
+            idx = torch.topk(vals, k=self.top_k, dim=-1).indices
+            idx_expand = idx[:, None, :, None].expand(-1, _C, -1, _T)
+            x = torch.gather(x, dim=2, index=idx_expand)
+            # Reshaping x from (batch_size, channels, top_k, kernel_size)
+            # to (batch_size, channels x top_k, kernel_size)
+            x = x.reshape(_B, _C * self.top_k, _T)
+        else:
+            # Reshaping x from
+            # (batch_size, channels, num_chirp_mass, kernel_size)
+            # to (batch_size, channels x num_chirp_mass, kernel_size)
+            x = x.reshape(_B, _C * self.num_chirp_masses, _T)
         x_heterodyned[:, :, :] = x
         # Returning the desired length of heterodyned strain in the
         # time dimension

--- a/projects/export/export_heterodyne.yaml
+++ b/projects/export/export_heterodyne.yaml
@@ -9,7 +9,7 @@ weights:
 batch_file:
 repository_directory:
 num_ifos: 2
-kernel_length: 4.0
+kernel_length: 8.0
 inference_sampling_rate: 4
 sample_rate: 2048
 batch_size: 128
@@ -18,7 +18,7 @@ psd_length: 64
 preprocessor:
   class_path: utils.preprocessing.BatchWhitener
   init_args:
-    kernel_length: 4.0
+    kernel_length: 8.0
     sample_rate: 2048
     inference_sampling_rate: 4
     batch_size: 128
@@ -28,12 +28,13 @@ preprocessor:
       class_path: utils.augmentation.HeterodyneAugmentor
       init_args:
         sample_rate: 2048
-        kernel_length: 4.0
+        kernel_length: 8.0
         chirp_mass_low: 1.0
         chirp_mass_high: 2.5 
         num_chirp_masses: 100
         chirp_mass_spacing: "log" 
         keep_last_n_seconds: null
+        top_k: 10
     highpass: 32.0
 streams_per_gpu: 12
 # num_outputs:

--- a/projects/online/config.yaml
+++ b/projects/online/config.yaml
@@ -52,13 +52,15 @@ state_channels: ["H1:GDS-CALIB_STATE_VECTOR", "L1:GDS-CALIB_STATE_VECTOR", "V1:D
 data_source: "frames"
 sample_rate: 2048
 astro_event_rate: 89
-kernel_length: 20
+kernel_length: 8
 online_inference_rate: 512
 offline_inference_rate: 16
-schedule: [[0, 16, 512], [16, 20, 2048]]
-split: True
-q: 45.6
-spectrogram: [64, 128]
+chirp_mass_low: 1.0
+chirp_mass_high: 2.5
+num_chirp_masses: 100
+chirp_mass_spacing: "log"
+keep_last_n_seconds: 1.5
+top_k: 10
 inference_params: ["chirp_mass", "mass_ratio", "luminosity_distance", "phic", "inclination", "dec", "psi", "phi"]
 psd_length: 64
 amplfi_psd_length: 10

--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -25,7 +25,8 @@ from online.dataloading import (
 from online.utils.pe import run_amplfi, warmup_amplfi
 from online.utils.searcher import Searcher
 from online.utils.snapshotter import OnlineSnapshotter
-from utils.preprocessing import TimeSpectrogramPreprocessor
+from utils.preprocessing import BatchWhitener
+from utils.augmentation import HeterodyneAugmentor
 from online.subprocesses import (
     amplfi_subprocess,
     pastro_subprocess,
@@ -147,7 +148,7 @@ def process_event(
 
 @torch.no_grad()
 def search(
-    whitener: TimeSpectrogramPreprocessor,
+    whitener: BatchWhitener,
     snapshotter: OnlineSnapshotter,
     searcher: Searcher,
     event_queue: Queue,
@@ -294,9 +295,9 @@ def search(
         # (significant performance speed up)
         if hl_ready:
             logging.debug("Performing inference")
-            y = aframe(*whitened)[0][:, 0]
+            y = aframe(whitened)[:, 0]
         else:
-            y = torch.ones(whitened[0].shape[0])
+            y = torch.ones(whitened.shape[0])
 
         # update our output buffer with the latest aframe output,
         # which will also automatically integrate the output
@@ -358,10 +359,10 @@ def main(
     kernel_length: float,
     online_inference_rate: float,
     offline_inference_rate: float,
-    schedule: list[list[int]],
-    split: bool,
-    q: float,
-    spectrogram_shape: list[int, int],
+    chirp_mass_low: float,
+    chirp_mass_high: float,
+    num_chirp_masses: int,
+    chirp_mass_spacing: Literal["linear", "log"],
     psd_length: float,
     amplfi_psd_length: float,
     aframe_right_pad: float,
@@ -372,6 +373,8 @@ def main(
     integration_window_length: float,
     astro_event_rate: float,
     data_source: Literal["frames", "ngdd"] = "frames",
+    keep_last_n_seconds: float = None,
+    top_k: int = None,
     state_channels: Optional[list[str]] = None,
     fftlength: Optional[float] = None,
     highpass: Optional[float] = None,
@@ -435,21 +438,22 @@ def main(
         offline_inference_rate:
             Rate at which inference was performed offline when
             establishing the background and foreground distributions
-        schedule:
-            It specifies which segments of the input to keep and at
-            what sampling rate. Each row of the schedule has the
-            form: [start_time, end_time, target_sample_rate]
-        split:
-            If `True`, then return a list of decimated segments based on
-            the schedule input. If `False`, then return a concatenated
-            single continuous output tensor.
-        q:
-            The Q value to use for the Q transform.
-        spectrogram_shape:
-            The shape of the interpolated spectrogram, specified as
-            ``(num_f_bins, num_t_bins)``. Because the frequency spacing
-            of the Q-tiles is in log-space, the frequency interpolation
-            is log-spaced as well.
+        chirp_mass_low:
+            Lower bound of chirp mass range (in solar masses).
+        chirp_mass_high:
+            Upper bound of chirp mass range (in solar masses).
+        num_chirp_masses:
+            Number of chirp mass samples to generate.
+        chirp_mass_spacing:
+            Spacing of chirp mass grid. Use "linear" for evenly spaced
+            values or "log" for logarithmic spacing.
+        keep_last_n_seconds:
+            If provided, only the last `n` seconds of the kernel_length are
+            returned. Otherwise, the full kernel_length is returned.
+        top_k:
+            If provided, only the top `k` chirp mass channels are chosen
+            for the heterodyned timeseries. Otherwise, all chirp mass
+            channels are returned.
         psd_length:
             Length of PSD estimation window in seconds for PSD
             used to whiten aframe data
@@ -819,17 +823,23 @@ def main(
         lowpass=lowpass,
     ).to(device)
 
-    whitener = TimeSpectrogramPreprocessor(
+    whitener = BatchWhitener(
         kernel_length=kernel_length,
         sample_rate=sample_rate,
         inference_sampling_rate=online_inference_rate,
         batch_size=update_size * online_inference_rate,
         fduration=fduration,
         fftlength=fftlength,
-        schedule=schedule,
-        split=split,
-        q=q,
-        spectrogram_shape=spectrogram_shape,
+        augmentor=HeterodyneAugmentor(
+            sample_rate=sample_rate,
+            kernel_length=kernel_length,
+            chirp_mass_low=chirp_mass_low,
+            chirp_mass_high=chirp_mass_high,
+            num_chirp_masses=num_chirp_masses,
+            chirp_mass_spacing=chirp_mass_spacing,
+            keep_last_n_seconds=keep_last_n_seconds,
+            top_k=top_k,
+        ),
         highpass=highpass,
         lowpass=lowpass,
     ).to(device)

--- a/projects/train/configs/time_heterodyne.yaml
+++ b/projects/train/configs/time_heterodyne.yaml
@@ -13,7 +13,7 @@ model:
       class_path: architectures.supervised.SupervisedHeterodyneTimeDomainResNet
       init_args:
         layers: [3, 4, 6, 3]
-        kernel_size: 25
+        kernel_size: 3
         norm_layer:
           class_path: ml4gw.nn.norm.GroupNorm1DGetter
           init_args:
@@ -37,12 +37,12 @@ data:
     waveforms_dir:
     ifos: [H1,L1]
     sample_rate: 2048
-    batches_per_epoch: 100
+    batches_per_epoch: 200
     num_files_per_batch: 10
-    chunk_size: 1000
+    chunk_size: 5000
     chunks_per_epoch: 20
     # preprocessing args
-    batch_size: 100
+    batch_size: 2000
     kernel_length: 8
     psd_length: 20
     fduration: 2
@@ -57,25 +57,26 @@ data:
     chirp_mass_high: 2.5
     num_chirp_masses: 100
     chirp_mass_spacing: "log"
-    keep_last_n_seconds: null
+    keep_last_n_seconds: 1.5
+    top_k: 10
     # highpass: 
     # lowpass: 
     fftlength: 2
-    snr_sampler:
-      class_path: ml4gw.distributions.PowerLaw
-      init_args: 
-        minimum: 8
-        maximum: 100
-        index: -3
-    # curriculum learning for snr sampler
     # snr_sampler:
-    #   class_path: train.augmentations.SnrSampler
-    #   init_args:
-    #     max_min_snr: 30
-    #     min_min_snr: 8
-    #     max_snr: 100
-    #     alpha: -3
-    #     decay_steps: 600
+    #   class_path: ml4gw.distributions.PowerLaw
+    #   init_args: 
+    #     minimum: 8
+    #     maximum: 100
+    #     index: -3
+    # curriculum learning for snr sampler
+    snr_sampler:
+      class_path: train.augmentations.SnrSampler
+      init_args:
+        max_min_snr: 30
+        min_min_snr: 8
+        max_snr: 100
+        alpha: -3
+        decay_steps: 600
     waveform_sampler:
       class_path: train.data.waveforms.WaveformLoader
       init_args:

--- a/projects/train/train/cli.py
+++ b/projects/train/train/cli.py
@@ -57,12 +57,21 @@ class AframeCLI(LightningCLI):
         except Exception:
             pass
 
-        # TODO: This is a workaround for linking num_chirp_masses between
-        # the model and the architecture for in_channels.
+        # TODO: This is a workaround for linking num_chirp_masses and
+        # top_k channel argument between the model and the architecture
+        # for in_channels.
         try:
             parser.link_arguments(
                 "data.init_args.num_chirp_masses",
                 "model.init_args.arch.init_args.num_chirp_masses",
+            )
+        except Exception:
+            pass
+
+        try:
+            parser.link_arguments(
+                "data.init_args.top_k",
+                "model.init_args.arch.init_args.top_k",
             )
         except Exception:
             pass

--- a/projects/train/train/data/supervised/time_domain.py
+++ b/projects/train/train/data/supervised/time_domain.py
@@ -1,10 +1,10 @@
 import math
 import torch
-import torch.nn.functional as F
 from typing import Literal
 
 from train.data.supervised.supervised import SupervisedAframeDataset
 from ml4gw.transforms import Heterodyne
+from utils.augmentation import SelectTopK
 
 
 class TimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
@@ -47,9 +47,9 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
             If provided, only the last `n` seconds of the kernel_length are
             returned. Otherwise, the full kernel_length is returned.
         top_k (int):
-            If provided, only the top `k` chirp mass channels are chosen
-            for the heterodyned timeseries. Otherwise, all chirp mass
-            channels are returned.
+            If provided, the top `k` chirp mass channels are selected based on
+            their absolute amplitude, corresponding to the `k` matching chirp
+            masses with. If `None`, all chirp mass channels are returned.
     """
 
     def __init__(
@@ -77,6 +77,14 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         if self.keep_last_n_seconds is not None:
             self.keep_last_n_samples = int(
                 self.keep_last_n_seconds * self.hparams.sample_rate
+            )
+        else:
+            self.keep_last_n_samples = None
+
+        if self.top_k is not None:
+            self.select_top_k = SelectTopK(
+                keep_last_n_samples=self.keep_last_n_samples,
+                top_k=self.top_k,
             )
 
     def build_transforms(self, *args, **kwargs):
@@ -110,43 +118,19 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
                 f"Invalid chirp mass spacing: {chirp_mass_spacing}"
             )
 
-    def _select_top_k(self, X):
-        B, C, M, T = X.shape
-        # If no top-k requested, flatten the chirp-mass dimension
-        if self.top_k is None:
-            return X.reshape(B, C * M, T)
-        _X = []
-        for b in range(B):
-            x = X[b]
-            avgpool = F.avg_pool1d(
-                torch.abs(x.reshape(C * M, T)),
-                kernel_size=31,
-                stride=1,
-                padding=15,
-            ).reshape(C, M, T)
-            if self.keep_last_n_seconds is not None:
-                avgpool_snr = torch.sqrt(
-                    (avgpool[..., -self.keep_last_n_samples :] ** 2).sum(dim=0)
-                )
-            else:
-                avgpool_snr = torch.sqrt((avgpool**2).sum(dim=0))
-            vals = avgpool_snr.max(dim=-1).values
-            idx = torch.topk(vals, k=self.top_k).indices
-            idx = idx[None, :, None].expand(C, -1, T)
-            _X.append(torch.gather(x, dim=1, index=idx))
-        return torch.stack(_X).reshape(B, C * self.top_k, T)
-
     def build_val_batches(self, background, signals):
         X_bg, X_inj, psds = super().build_val_batches(background, signals)
         X_bg = self.whitener(X_bg, psds)
         X_bg = self.heterodyne_transform(X_bg)
-        X_bg = self._select_top_k(X_bg)
+        if self.top_k is not None:
+            X_bg = self.select_top_k(X_bg)
         # whiten each view of injections
         X_fg = []
         for inj in X_inj:
             inj = self.whitener(inj, psds)
             inj = self.heterodyne_transform(inj)
-            inj = self._select_top_k(inj)
+            if self.top_k is not None:
+                inj = self.select_top_k(inj)
             X_fg.append(inj)
         X_fg = torch.stack(X_fg)
 
@@ -161,7 +145,8 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X, y, psds = super().inject(X, waveforms)
         X = self.whitener(X, psds)
         X = self.heterodyne_transform(X)
-        X = self._select_top_k(X)
+        if self.top_k is not None:
+            X = self.select_top_k(X)
 
         if self.keep_last_n_seconds is not None:
             return X[..., -self.keep_last_n_samples :], y

--- a/projects/train/train/data/supervised/time_domain.py
+++ b/projects/train/train/data/supervised/time_domain.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from train.data.supervised.supervised import SupervisedAframeDataset
 from ml4gw.transforms import Heterodyne
-from utils.augmentation import SelectTopK
+from utils.augmentation import select_top_k
 
 
 class TimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
@@ -81,12 +81,6 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         else:
             self.keep_last_n_samples = None
 
-        if self.top_k is not None:
-            self.select_top_k = SelectTopK(
-                keep_last_n_samples=self.keep_last_n_samples,
-                top_k=self.top_k,
-            )
-
     def build_transforms(self, *args, **kwargs):
         super().build_transforms(*args, **kwargs)
         self.heterodyne_transform = Heterodyne(
@@ -123,14 +117,20 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X_bg = self.whitener(X_bg, psds)
         X_bg = self.heterodyne_transform(X_bg)
         if self.top_k is not None:
-            X_bg = self.select_top_k(X_bg)
+            X_bg = select_top_k(
+                X_bg, self.top_k, keep_last_n_samples=self.keep_last_n_samples
+            )
         # whiten each view of injections
         X_fg = []
         for inj in X_inj:
             inj = self.whitener(inj, psds)
             inj = self.heterodyne_transform(inj)
             if self.top_k is not None:
-                inj = self.select_top_k(inj)
+                inj = select_top_k(
+                    inj,
+                    self.top_k,
+                    keep_last_n_samples=self.keep_last_n_samples,
+                )
             X_fg.append(inj)
         X_fg = torch.stack(X_fg)
 
@@ -146,7 +146,9 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X = self.whitener(X, psds)
         X = self.heterodyne_transform(X)
         if self.top_k is not None:
-            X = self.select_top_k(X)
+            X = select_top_k(
+                X, self.top_k, keep_last_n_samples=self.keep_last_n_samples
+            )
 
         if self.keep_last_n_seconds is not None:
             return X[..., -self.keep_last_n_samples :], y

--- a/projects/train/train/data/supervised/time_domain.py
+++ b/projects/train/train/data/supervised/time_domain.py
@@ -1,5 +1,6 @@
 import math
 import torch
+import torch.nn.functional as F
 from typing import Literal
 
 from train.data.supervised.supervised import SupervisedAframeDataset
@@ -45,6 +46,10 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         keep_last_n_seconds (float):
             If provided, only the last `n` seconds of the kernel_length are
             returned. Otherwise, the full kernel_length is returned.
+        top_k (int):
+            If provided, only the top `k` chirp mass channels are chosen
+            for the heterodyned timeseries. Otherwise, all chirp mass
+            channels are returned.
     """
 
     def __init__(
@@ -54,6 +59,7 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         num_chirp_masses: int = 100,
         chirp_mass_spacing: Literal["linear", "log"] = "log",
         keep_last_n_seconds: float = None,
+        top_k: int = None,
         *args,
         **kwargs,
     ):
@@ -67,7 +73,7 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         )
 
         self.keep_last_n_seconds = keep_last_n_seconds
-
+        self.top_k = top_k
         if self.keep_last_n_seconds is not None:
             self.keep_last_n_samples = int(
                 self.keep_last_n_seconds * self.hparams.sample_rate
@@ -104,21 +110,45 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
                 f"Invalid chirp mass spacing: {chirp_mass_spacing}"
             )
 
+    def _select_top_k(self, X):
+        B, C, M, T = X.shape
+        # If no top-k requested, flatten the chirp-mass dimension
+        if self.top_k is None:
+            return X.reshape(B, C * M, T)
+        _X = []
+        for b in range(B):
+            x = X[b]
+            avgpool = F.avg_pool1d(
+                torch.abs(x.reshape(C * M, T)),
+                kernel_size=31,
+                stride=1,
+                padding=15,
+            ).reshape(C, M, T)
+            if self.keep_last_n_seconds is not None:
+                avgpool_snr = torch.sqrt(
+                    (avgpool[..., -self.keep_last_n_samples :] ** 2).sum(dim=0)
+                )
+            else:
+                avgpool_snr = torch.sqrt((avgpool**2).sum(dim=0))
+            vals = avgpool_snr.max(dim=-1).values
+            idx = torch.topk(vals, k=self.top_k).indices
+            idx = idx[None, :, None].expand(C, -1, T)
+            _X.append(torch.gather(x, dim=1, index=idx))
+        return torch.stack(_X).reshape(B, C * self.top_k, T)
+
     def build_val_batches(self, background, signals):
         X_bg, X_inj, psds = super().build_val_batches(background, signals)
         X_bg = self.whitener(X_bg, psds)
         X_bg = self.heterodyne_transform(X_bg)
-        _B_bg, _C_bg, _M_bg, _T_bg = X_bg.shape
-        X_bg = X_bg.view(_B_bg, _C_bg * _M_bg, _T_bg)
+        X_bg = self._select_top_k(X_bg)
         # whiten each view of injections
         X_fg = []
         for inj in X_inj:
             inj = self.whitener(inj, psds)
             inj = self.heterodyne_transform(inj)
+            inj = self._select_top_k(inj)
             X_fg.append(inj)
         X_fg = torch.stack(X_fg)
-        _V_fg, _B_fg, _C_fg, _M_fg, _T_fg = X_fg.shape
-        X_fg = X_fg.view(_V_fg, _B_fg, _C_fg * _M_fg, _T_fg)
 
         if self.keep_last_n_seconds is not None:
             return X_bg[..., -self.keep_last_n_samples :], X_fg[
@@ -131,8 +161,7 @@ class HeterodyneTimeDomainSupervisedAframeDataset(SupervisedAframeDataset):
         X, y, psds = super().inject(X, waveforms)
         X = self.whitener(X, psds)
         X = self.heterodyne_transform(X)
-        _B, _C, _M, _T = X.shape
-        X = X.view(_B, _C * _M, _T)
+        X = self._select_top_k(X)
 
         if self.keep_last_n_seconds is not None:
             return X[..., -self.keep_last_n_samples :], y


### PR DESCRIPTION
In this PR, I have added the `top-k` functionality across the `train`, `export`, and `online' projects for the `heterodyne` models. I didn't get a chance to test the `online` project because I changed the previous `TimeSpectrogramPreprocessor` used in the BNS O3 MDC in Feb 2026. Some of the coding choices in the train datamodule or preprocessor could be made better, and I'm open to suggestions. Once we finalize this PR, I'm aiming to run it on the O3 MDC to repeat the exercise from earlier this year.