### PR TITLE
make gracedb kafka producer bootstrap server an env variable

### DIFF
--- a/projects/online/online/main.py
+++ b/projects/online/online/main.py
@@ -376,6 +376,7 @@ def main(
     refractory_period: float = 8,
     far_threshold: float = 1,
     server: "GdbServer" = "local",
+    gracedb_kafka_bootstrap_server: str = "kafkagracedb1.igwn.org:9092",
     ifo_suffix: str = None,
     input_buffer_length: int = 75,
     output_buffer_length: int = 8,
@@ -469,6 +470,8 @@ def main(
         server:
             GraceDB server to use:
             "local", "playground", "test" or "production"
+        gracedb_kafka_bootstrap_server:
+            Kafka bootstrap server address for GraceDB event submission.
         ifo_suffix:
             Optional suffix for accessing data from /dev/shm.
             Useful when analyzing alternative streams like
@@ -638,6 +641,7 @@ def main(
         outdir / "events",
         amplfi_queue,
         pastro_queue,
+        gracedb_kafka_bootstrap_server,
     )
     event_process = Process(
         target=event_creation_subprocess,

--- a/projects/online/online/subprocesses/events.py
+++ b/projects/online/online/subprocesses/events.py
@@ -1,4 +1,5 @@
 from queue import Queue
+import os
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -29,7 +30,7 @@ def event_creation_subprocess(
 
     # Need to create the producer within the subprocess that uses it
     gdb.kafka_producer = GraceDbKafkaProducer(
-        bootstrap_servers="kafka-dev.ligo.org:9092",
+        bootstrap_servers=os.getenv("GRACEDB_KAFKA_BOOTSTRAP_SERVERS"),
         service_url=gdb.server.service_url,
         ca_cert_path=certifi.where(),
     )

--- a/projects/online/online/subprocesses/events.py
+++ b/projects/online/online/subprocesses/events.py
@@ -1,5 +1,4 @@
 from queue import Queue
-import os
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -22,6 +21,7 @@ def event_creation_subprocess(
     outdir: Path,
     amplfi_queue: Queue,
     pastro_queue: Queue,
+    gracedb_kafka_bootstrap_server: str,
 ):
     logger.info("event creation subprocess initialized")
 
@@ -30,7 +30,7 @@ def event_creation_subprocess(
 
     # Need to create the producer within the subprocess that uses it
     gdb.kafka_producer = GraceDbKafkaProducer(
-        bootstrap_servers=os.getenv("GRACEDB_KAFKA_BOOTSTRAP_SERVERS"),
+        bootstrap_servers=gracedb_kafka_bootstrap_server,
         service_url=gdb.server.service_url,
         ca_cert_path=certifi.where(),
     )

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -109,6 +109,10 @@ def create_online_runfile(path: Path):
     cmd = "apptainer run --nv "
     # bind /local/aframe for finding scitokens
     cmd += "--bind /local/aframe.online,$ONLINE_DATADIR"
+    cmd += (
+        "--env GRACEDB_KAFKA_BOOTSTRAP_SERVERS="
+        "$GRACEDB_KAFKA_BOOTSTRAP_SERVERS "
+    )
     cmd += "--env CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES "
     cmd += "--env AFRAME_ONLINE_OUTDIR=$AFRAME_ONLINE_OUTDIR "
     cmd += "--env ONLINE_DATADIR=$ONLINE_DATADIR "
@@ -175,6 +179,9 @@ def create_online_runfile(path: Path):
 
     # Location of Aframe containers
     export AFRAME_CONTAINER=$HOME/images/aframe/online.sif
+    
+    # GraceDB Kafka bootstrap servers
+    export GRACEDB_KAFKA_BOOTSTRAP_SERVERS="kafkagracedb1.igwn.org:9092"
 
     config=$RUN_DIR/config.yaml
 

--- a/scripts/aframe_init.py
+++ b/scripts/aframe_init.py
@@ -109,10 +109,6 @@ def create_online_runfile(path: Path):
     cmd = "apptainer run --nv "
     # bind /local/aframe for finding scitokens
     cmd += "--bind /local/aframe.online,$ONLINE_DATADIR"
-    cmd += (
-        "--env GRACEDB_KAFKA_BOOTSTRAP_SERVERS="
-        "$GRACEDB_KAFKA_BOOTSTRAP_SERVERS "
-    )
     cmd += "--env CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES "
     cmd += "--env AFRAME_ONLINE_OUTDIR=$AFRAME_ONLINE_OUTDIR "
     cmd += "--env ONLINE_DATADIR=$ONLINE_DATADIR "
@@ -179,9 +175,6 @@ def create_online_runfile(path: Path):
 
     # Location of Aframe containers
     export AFRAME_CONTAINER=$HOME/images/aframe/online.sif
-    
-    # GraceDB Kafka bootstrap servers
-    export GRACEDB_KAFKA_BOOTSTRAP_SERVERS="kafkagracedb1.igwn.org:9092"
 
     config=$RUN_DIR/config.yaml
 


### PR DESCRIPTION
In this PR, I have updated the GraceDB Kafka producer's `bootstrap_server `to be an environment variable. This gives flexibility to change the server directly from `run.sh`.